### PR TITLE
Fix strictness

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -31,7 +31,7 @@ npm install @remote-ui/core --save
 This function accepts two arguments:
 
 - `channel` is a `RemoteChannel`, a function that will be called with serialized representation of UI updates. [`RemoteReceiver#receive`](#remotereceiverreceive) is one such function, and most uses of remote-ui will rely on connecting those two “sides” by passing the `receive` method for this argument.
-- `options` is an optional options object. There is currently one supported option: `components`. This value is the list of components that can be constructed and attached to this root. This is necessary because, by default, this library does not supply any components to render; you are responsible for implementing a component API that makes sense for your use case.
+- `options` is an optional options object. There is currently one supported option: `strict`, which is enabled by default. When enabled, all `props` and `children` for remote components will be frozen (with `Object.freeze()`) in order to prevent direct mutation of those values (to prevent unexpected behavior, all mutations to these values should be done with the [`RemoteComponent`](#remotecomponent) API). The default `strict`ness also prevents potentially-untrusted code from adding properties or children that it is not supposed to. However, `Object.freeze` does have a small runtime cost, so if you are comfortable without this safety, you can disable it by passing `strict: false`:
 
 ```ts
 import {createRemoteRoot, RemoteReceiver} from '@remote-ui/core';
@@ -39,7 +39,7 @@ import {createRemoteRoot, RemoteReceiver} from '@remote-ui/core';
 const receiver = new RemoteReceiver();
 
 const root = createRemoteRoot(receiver.receive, {
-  components: ['Button', 'TextField', 'Card'],
+  strict: false,
 });
 ```
 

--- a/packages/react/src/host/hooks.ts
+++ b/packages/react/src/host/hooks.ts
@@ -38,7 +38,7 @@ export function useAttached<T extends Attachable>(
     // If the subscription has been updated, we'll schedule another update with React.
     // React will process this update immediately, so the old subscription value won't be committed.
     // It is still nice to avoid returning a mismatched value though, so let's override the return value.
-    returnValue = receiver.get(attached);
+    returnValue = {...receiver.get(attached)};
 
     setState({
       receiver,
@@ -56,8 +56,6 @@ export function useAttached<T extends Attachable>(
         return;
       }
 
-      const value = receiver.get(attached);
-
       setState((previousState) => {
         const {
           receiver: previousReceiver,
@@ -69,13 +67,15 @@ export function useAttached<T extends Attachable>(
           return previousState;
         }
 
+        const value = {...receiver.get(attached)};
+
         // If the value hasn't changed, no update is needed.
         // Return state as-is so React can bail out and avoid an unnecessary render.
-        if (deepEqual(previousValue, value)) {
+        if (shallowEqual(previousValue, value)) {
           return previousState;
         }
 
-        return {...previousState, value: {...value}};
+        return {receiver, value};
       });
     };
 
@@ -93,7 +93,7 @@ export function useAttached<T extends Attachable>(
   return returnValue;
 }
 
-function deepEqual<T>(one: T, two: T) {
+function shallowEqual<T>(one: T, two: T) {
   return Object.keys(two).every(
     (key) => (one as any)[key] === (two as any)[key],
   );


### PR DESCRIPTION
This PR fixes some cases where `props` and `children` were not frozen, allowing them to be directly mutated. It also adds an option to disable strictness, which can slightly improve performance in apps that don't need the immutable guarantees.