### PR TITLE
Fix timing issue in React host

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2020-06-25
+
+- Fixed the type of `RemoteReceiver#get()` to correctly indicate that an attached element may be `null`.
+
 ## [1.2.1] - 2020-06-25
 
 - Fixed an error that prevented strings from being passed in the array of children for `RemoteRoot#createComponent()`.
@@ -27,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a `strict` option to control immutability in `@remote-ui/core`’s `createRemoteRoot()` ([pull request](https://github.com/Shopify/remote-ui/pull/16))
+- Added a `strict` option to control immutability in `@remote-ui/core`’s `createRemoteRoot()` ([pull request](https://github.com/Shopify/remote-ui/pull/16)).
 
 ## [1.0.1] - 2020-06-23
 

--- a/packages/core/src/receiver.ts
+++ b/packages/core/src/receiver.ts
@@ -130,8 +130,8 @@ export class RemoteReceiver {
     Set<UpdateListener<any>>
   >();
 
-  get<T extends Attachable>({id}: T) {
-    return this.attached.get(id) as T;
+  get<T extends Attachable>({id}: T): T | null {
+    return (this.attached.get(id) as T | undefined) ?? null;
   }
 
   listen<T extends Attachable>({id}: T, listener: UpdateListener<T>) {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6] - 2020-06-25
+
+- Fixed an issue where the `RemoteRenderer` component would throw an error if a remote component was removed from the tree while its host representation was in the process of mounting.
+
 ## [1.0.3] - 2020-06-24
 
 ### Fixed

--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -19,8 +19,10 @@ interface Props {
 
 export const RemoteComponent = memo(
   ({receiver, component, controller}: Props) => {
-    const {props, children} = useAttached(receiver, component);
     const Implementation = controller.get(component.type)!;
+
+    const attached = useAttached(receiver, component);
+    const props = attached?.props;
 
     useEffect(() => {
       retain(props);
@@ -29,6 +31,10 @@ export const RemoteComponent = memo(
         release(props);
       };
     }, [props]);
+
+    if (attached == null) return null;
+
+    const {children} = attached;
 
     return createElement(
       Implementation,

--- a/packages/react/src/host/RemoteText.tsx
+++ b/packages/react/src/host/RemoteText.tsx
@@ -13,6 +13,6 @@ interface Props {
 }
 
 export const RemoteText = memo(({text, receiver}: Props) => {
-  const {text: textContent} = useAttached(receiver, text);
-  return <>{textContent}</>;
+  const attached = useAttached(receiver, text);
+  return attached ? <>{attached.text}</> : null;
 });

--- a/packages/react/src/host/Renderer.tsx
+++ b/packages/react/src/host/Renderer.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export const RemoteRenderer = memo(({components, receiver}: Props) => {
   const controller = useMemo(() => new Controller(components), [components]);
-  const {children} = useAttached(receiver, receiver.root);
+  const {children} = useAttached(receiver, receiver.root)!;
 
   return createElement(
     Fragment,

--- a/packages/react/src/host/hooks.ts
+++ b/packages/react/src/host/hooks.ts
@@ -25,23 +25,40 @@ export function useRemoteReceiver() {
 
 type Attachable = Parameters<RemoteReceiver['listen']>[0];
 
+interface State<T extends Attachable> {
+  receiver: RemoteReceiver;
+  attached: T;
+  value: T | null;
+}
+
 export function useAttached<T extends Attachable>(
   receiver: RemoteReceiver,
   attached: T,
 ) {
-  const [state, setState] = useState({receiver, value: {...attached}});
+  const [state, setState] = useState<State<T>>({
+    receiver,
+    attached,
+    value: {...attached},
+  });
 
-  let returnValue = state.value;
+  let returnValue: T | null = state.value;
 
   // If parameters have changed since our last render, schedule an update with its current value.
-  if (state.receiver !== receiver || state.value.id !== attached.id) {
+  if (state.receiver !== receiver || state.attached.id !== attached.id) {
+    // When the consumer of this hook changes receiver or attached node, the node they switched
+    // to might already be unmounted. We guard against that by making sure we don’t get null
+    // back from the receiver, and storing the “attached” node in state whether it is actually
+    // attached or not, so we have a paper trail of how we got here.
+    const updated = receiver.get(attached);
+
     // If the subscription has been updated, we'll schedule another update with React.
     // React will process this update immediately, so the old subscription value won't be committed.
     // It is still nice to avoid returning a mismatched value though, so let's override the return value.
-    returnValue = {...receiver.get(attached)};
+    returnValue = updated && {...updated};
 
     setState({
       receiver,
+      attached,
       value: returnValue,
     });
   }
@@ -67,7 +84,14 @@ export function useAttached<T extends Attachable>(
           return previousState;
         }
 
-        const value = {...receiver.get(attached)};
+        // This function is also called as part of the initial useEffect() when the
+        // component mounts. It’s possible that between the initial render (when the
+        // remote component was for sure attached, to the best of the host’s knowledge)
+        // and the effect, the component was removed from the remote tree. You’ll see that
+        // the rest of this callback is careful to handle cases where the node is in this
+        // state.
+        const current = receiver.get(attached);
+        const value = current && {...current};
 
         // If the value hasn't changed, no update is needed.
         // Return state as-is so React can bail out and avoid an unnecessary render.
@@ -75,7 +99,7 @@ export function useAttached<T extends Attachable>(
           return previousState;
         }
 
-        return {receiver, value};
+        return {receiver, attached, value};
       });
     };
 
@@ -94,6 +118,9 @@ export function useAttached<T extends Attachable>(
 }
 
 function shallowEqual<T>(one: T, two: T) {
+  if (one == null) return two == null;
+  if (two == null) return false;
+
   return Object.keys(two).every(
     (key) => (one as any)[key] === (two as any)[key],
   );


### PR DESCRIPTION
This PR fixes an issue where the React host would throw an error in the case where a remote component was removed from the tree while its host representation was in the process of mounting.

All the credit goes to @henrytao-me for fixing this on our private fork ❤️ 