### PR TITLE
pass endpoint options kn createWorker

### DIFF
--- a/packages/rpc/src/endpoint.ts
+++ b/packages/rpc/src/endpoint.ts
@@ -25,7 +25,7 @@ interface MessageMap {
   [FUNCTION_RESULT]: [string, Error?, any?];
 }
 
-interface Options<T = unknown> {
+export interface CreateEndpointOptions<T = unknown> {
   uuid?(): string;
   createEncoder?(api: EncodingStrategyApi): EncodingStrategy;
   callable?: (keyof T)[];
@@ -68,7 +68,7 @@ export function createEndpoint<T>(
     uuid = defaultUuid,
     createEncoder = createBasicEncoder,
     callable,
-  }: Options<T> = {},
+  }: CreateEndpointOptions<T> = {},
 ): Endpoint<T> {
   let terminated = false;
   let messenger = initialMessenger;

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -1,5 +1,5 @@
 export {createEndpoint} from './endpoint';
-export type {Endpoint} from './endpoint';
+export type {Endpoint, CreateEndpointOptions} from './endpoint';
 export {createBasicEncoder} from './encoding';
 export {fromMessagePort, fromWebWorker} from './adaptors';
 export {

--- a/packages/web-workers/src/create/worker.ts
+++ b/packages/web-workers/src/create/worker.ts
@@ -1,14 +1,19 @@
-import {createEndpoint, Endpoint, MessageEndpoint} from '@remote-ui/rpc';
+import {
+  createEndpoint,
+  Endpoint,
+  MessageEndpoint,
+  CreateEndpointOptions,
+} from '@remote-ui/rpc';
 import {createWorkerMessenger} from '../messenger';
 import {createScriptUrl, FileOrModuleResolver} from './utilities';
 
-export interface CreateWorkerOptions {
+export interface CreateWorkerOptions<T> extends CreateEndpointOptions<T> {
   createMessenger?(url: URL): MessageEndpoint;
 }
 
 export interface WorkerCreator<T> {
   readonly url?: URL;
-  (options?: CreateWorkerOptions): Endpoint<T>['call'];
+  (options?: CreateWorkerOptions<T>): Endpoint<T>['call'];
 }
 
 const workerEndpointCache = new WeakMap<Endpoint<any>['call'], Endpoint<any>>();
@@ -20,9 +25,13 @@ export function createWorkerFactory<T = unknown>(
 
   function createWorker({
     createMessenger = createWorkerMessenger,
-  }: CreateWorkerOptions = {}): Endpoint<T>['call'] {
+    ...endpointOptions
+  }: CreateWorkerOptions<T> = {}): Endpoint<T>['call'] {
     if (scriptUrl) {
-      const endpoint = createEndpoint(createMessenger(scriptUrl));
+      const endpoint = createEndpoint(
+        createMessenger(scriptUrl),
+        endpointOptions,
+      );
       const {call: caller} = endpoint;
 
       workerEndpointCache.set(caller, endpoint);


### PR DESCRIPTION
Mainly to allow to pass `callable` to make workers work in IE and other envs that don't support proxies.