### PR TITLE
Support type override

### DIFF
--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -14,7 +14,9 @@ interface Props {
   receiver: RemoteReceiver;
   component: Serialized<RemoteComponentDescription<any, any>>;
   controller: Controller;
-  __type__?: React.ReactChild;
+  // Type override allows components to bypass default wrapping behavior, specifically in Argo Admin which uses Polaris to render on the host. Ex: Stack, ResourceList...
+  // See https://github.com/Shopify/app-extension-libs/issues/996#issuecomment-710437088
+  __type__?: React.ComponentType;
 }
 
 export const RemoteComponent = memo(

--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -14,6 +14,7 @@ interface Props {
   receiver: RemoteReceiver;
   component: Serialized<RemoteComponentDescription<any, any>>;
   controller: Controller;
+  __type__?: React.ReactChild;
 }
 
 export const RemoteComponent = memo(
@@ -46,6 +47,7 @@ export const RemoteComponent = memo(
               receiver={receiver}
               component={child}
               controller={controller}
+              __type__={(controller.get(child.type) as any)?.__type__}
             />
           );
         } else {

--- a/packages/react/src/host/Renderer.tsx
+++ b/packages/react/src/host/Renderer.tsx
@@ -26,6 +26,7 @@ export const RemoteRenderer = memo(({components, receiver}: Props) => {
           component={child}
           receiver={receiver}
           controller={controller}
+          __type__={(controller.get(child.type) as any)?.__type__}
         />
       ) : (
         <RemoteText key={child.id} text={child} receiver={receiver} />


### PR DESCRIPTION
This changes allows Argo to bypass Polaris type check when rendering StackItem.

Ref https://github.com/Shopify/app-extension-libs/issues/996
