### PR TITLE
Better core library

### DIFF
--- a/packages/core/src/root.ts
+++ b/packages/core/src/root.ts
@@ -142,6 +142,9 @@ export function createRemoteRoot<
         get props() {
           return internals.externalProps;
         },
+        get remoteProps() {
+          return internals.internalProps;
+        },
         updateProps: (newProps) =>
           updateProps(component, newProps, internals, rootInternals),
         appendChild: (child) =>
@@ -776,7 +779,7 @@ function serialize(value: AnyChild): Serialized<typeof value> {
     : {
         id: value.id,
         type: value.type,
-        props: value.props,
+        props: value.remoteProps,
         children: value.children.map((child) => serialize(child as any)),
       };
 }

--- a/packages/core/src/root.ts
+++ b/packages/core/src/root.ts
@@ -214,6 +214,8 @@ export function createRemoteRoot<
         rootInternals,
       ),
     mount() {
+      if (rootInternals.mounted) return Promise.resolve();
+
       rootInternals.mounted = true;
       return Promise.resolve(
         channel(ACTION_MOUNT, rootInternals.children.map(serialize)),

--- a/packages/core/src/root.ts
+++ b/packages/core/src/root.ts
@@ -140,7 +140,7 @@ export function createRemoteRoot<
           return internals.children;
         },
         get props() {
-          return internals.internalProps;
+          return internals.externalProps;
         },
         updateProps: (newProps) =>
           updateProps(component, newProps, internals, rootInternals),

--- a/packages/core/src/root.ts
+++ b/packages/core/src/root.ts
@@ -561,7 +561,7 @@ function tryHotSwappingValues(
   return [currentValue === newValue ? IGNORE : newValue];
 }
 
-function makeValueHotSwappable(value: unknown) {
+function makeValueHotSwappable(value: unknown): unknown {
   if (typeof value === 'function') {
     const wrappedFunction: HotSwappableFunction<any> = ((...args: any[]) => {
       return wrappedFunction[FUNCTION_CURRENT_IMPLEMENTATION_KEY](...args);
@@ -579,6 +579,13 @@ function makeValueHotSwappable(value: unknown) {
     );
 
     return wrappedFunction;
+  } else if (Array.isArray(value)) {
+    return value.map(makeValueHotSwappable);
+  } else if (typeof value === 'object' && value != null) {
+    return Object.keys(value).reduce<{[key: string]: any}>((newValue, key) => {
+      newValue[key] = makeValueHotSwappable((value as any)[key]);
+      return newValue;
+    }, {});
   }
 
   return value;

--- a/packages/core/src/tests/root.test.ts
+++ b/packages/core/src/tests/root.test.ts
@@ -1,7 +1,9 @@
 import {createRemoteRoot} from '../root';
+import {RemoteReceiver} from '../receiver';
+import type {RemoteChannel, RemoteComponent} from '../types';
 
 describe('root', () => {
-  describe('createComponent', () => {
+  describe('createComponent()', () => {
     it('does not throw error when no allowed components are set', () => {
       const root = createRemoteRoot(() => {});
 
@@ -38,7 +40,7 @@ describe('root', () => {
     });
   });
 
-  describe('createText', () => {
+  describe('createText()', () => {
     it('does not throw error when appending a child created by the remote root', () => {
       const components: string[] = [];
       const root = createRemoteRoot(() => {}, {components});
@@ -49,7 +51,7 @@ describe('root', () => {
     });
   });
 
-  describe('appendChild', () => {
+  describe('appendChild()', () => {
     it('does not throw error when appending a child created by the remote root', () => {
       const root = createRemoteRoot(() => {});
 
@@ -69,7 +71,7 @@ describe('root', () => {
     });
   });
 
-  describe('insertChildBefore', () => {
+  describe('insertChildBefore()', () => {
     it('does not throw error when calling insertChildBefore for a component created by the remote root', () => {
       const root = createRemoteRoot(() => {});
 
@@ -92,4 +94,79 @@ describe('root', () => {
       }).toThrowError();
     });
   });
+
+  describe('hot-swapping', () => {
+    it('hot-swaps function props', () => {
+      const funcOne = jest.fn();
+      const funcTwo = jest.fn();
+      const receiver = createDelayedReceiver();
+
+      const root = createRemoteRoot(receiver.receive);
+      const button = root.createComponent('Button', {onPress: funcOne});
+
+      root.appendChild(button);
+      root.mount();
+
+      // After this, the receiver will have the initial Button component
+      receiver.flush();
+
+      button.updateProps({onPress: funcTwo});
+
+      (receiver.children[0] as any).props.onPress();
+
+      expect(funcOne).not.toHaveBeenCalled();
+      expect(funcTwo).toHaveBeenCalled();
+    });
+
+    it('hot-swaps function props nested in objects and arrays', () => {
+      const funcOne = jest.fn();
+      const funcTwo = jest.fn();
+      const receiver = createDelayedReceiver();
+
+      const root = createRemoteRoot(receiver.receive);
+      const card = root.createComponent('Card', {
+        actions: [{onAction: funcOne}],
+      });
+
+      root.appendChild(card);
+      root.mount();
+
+      // After this, the receiver will have the initial Card component
+      receiver.flush();
+
+      card.updateProps({actions: [{onAction: funcTwo}]});
+
+      (receiver.children[0] as any).props.actions[0].onAction();
+
+      expect(funcOne).not.toHaveBeenCalled();
+      expect(funcTwo).toHaveBeenCalled();
+    });
+  });
 });
+
+function createDelayedReceiver() {
+  const receiver = new RemoteReceiver();
+  const enqueued = new Set<() => void>();
+
+  return {
+    get children() {
+      return receiver.root.children;
+    },
+    receive: ((type, ...args) => {
+      const perform = () => {
+        receiver.receive(type, ...args);
+        enqueued.delete(perform);
+      };
+
+      enqueued.add(perform);
+    }) as RemoteChannel,
+    flush() {
+      const currentlyEnqueued = [...enqueued];
+      enqueued.clear();
+
+      for (const perform of currentlyEnqueued) {
+        perform();
+      }
+    },
+  };
+}

--- a/packages/core/src/tests/root.test.ts
+++ b/packages/core/src/tests/root.test.ts
@@ -1,6 +1,6 @@
 import {createRemoteRoot} from '../root';
 import {RemoteReceiver} from '../receiver';
-import type {RemoteChannel, RemoteComponent} from '../types';
+import type {RemoteChannel} from '../types';
 
 describe('root', () => {
   describe('createComponent()', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -155,6 +155,7 @@ export interface RemoteComponent<
   readonly id: string;
   readonly type: IdentifierForRemoteComponent<Type>;
   readonly props: PropsForRemoteComponent<Type>;
+  readonly remoteProps: PropsForRemoteComponent<Type>;
   readonly children: readonly AllowedChildren<ExtractChildren<Type>, Root>[];
   readonly root: Root;
   readonly top: RemoteComponent<any, Root> | Root | null;


### PR DESCRIPTION
This supersedes https://github.com/Shopify/remote-ui/pull/31. It adds the same function-swapping capabilities as that PR did, but does it for `@remote-ui/core` instead of `@remote-ui/react`. This allows any library built on the core of remote-ui to have the same fixes when closing over state in function props. It also extends this logic to work for array and object props that contain nested functions, not just the functions that appear at the "top level" of the props object.

While I was here, I also rewrote a bunch of the core logic to avoid depending so heavily on `WeakMaps`, and instead have the `readonly` fields on remote nodes (`RemoteComponent#children`, `RemoteText#text`, etc) be implemented through closures instead.