### PR TITLE
Make it easier to provide children

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -71,11 +71,12 @@ If you are familiar with React, or if the “host” side of these components is
 
 To prevent this kind of mistake, any `children` prop will be deleted from the props object. If you want to implement a render prop-style API, you can do so without potentially causing confusion by using a different prop name, and ensuring that you handle the fact that the host will receive a promise whenever they call this function. If you are just trying to append other `RemoteComponent` and `RemoteText` instances to your tree, use `RemoteComponent#appendChild()`.
 
-`createComponent` also accepts a third argument: an array of children. This can be used to construct a tree of components without requiring intermediate variables.
+`createComponent` also allows you to pass initial children for the created component. If you have only one child, you can pass it directly as the third argument. If you have more than one child, you can either pass them as an array for the third argument, or as additional positional arguments. You can also pass a string directly, and it will be normalized into a `RemoteText` object for you.
 
 ```ts
 root.appendChild(
   root.createComponent('BlockStack', undefined, [
+    root.createComponent('Text', undefined, 'This will be fun!'),
     root.createComponent(
       'Button',
       {
@@ -83,7 +84,7 @@ root.appendChild(
           console.log('Pressed!');
         },
       },
-      ['Press me!'],
+      'Press me!',
     ),
   ]),
 );

--- a/packages/core/src/root.ts
+++ b/packages/core/src/root.ts
@@ -92,7 +92,7 @@ export function createRemoteRoot<
         throw new Error(`Unsupported component: ${type}`);
       }
 
-      const [initialProps, initialChildren] = rest;
+      const [initialProps, initialChildren, ...moreChildren] = rest;
 
       const normalizedInitialProps = initialProps ?? {};
       const normalizedInitialChildren: AnyChild[] = [];
@@ -117,8 +117,22 @@ export function createRemoteRoot<
       }
 
       if (initialChildren) {
-        for (const child of initialChildren) {
-          normalizedInitialChildren.push(normalizeChild(child, remoteRoot));
+        if (Array.isArray(initialChildren)) {
+          for (const child of initialChildren) {
+            normalizedInitialChildren.push(normalizeChild(child, remoteRoot));
+          }
+        } else {
+          normalizedInitialChildren.push(
+            normalizeChild(initialChildren, remoteRoot),
+          );
+
+          // The complex tuple type of `rest` makes it so `moreChildren` is
+          // incorrectly inferred as potentially being the props of the component,
+          // lazy casting since we know it will be an array of child elements
+          // (or empty).
+          for (const child of moreChildren as any[]) {
+            normalizedInitialChildren.push(normalizeChild(child, remoteRoot));
+          }
         }
       }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -80,6 +80,8 @@ type AllowedTextChildren<
   AllowString extends boolean = false
 > = AllowString extends true ? RemoteText<Root> | string : RemoteText<Root>;
 
+type MaybeArray<T> = T | T[];
+
 export interface RemoteRoot<
   AllowedComponents extends RemoteComponentType<
     string,
@@ -120,24 +122,34 @@ export interface RemoteRoot<
     ...rest: IfAllOptionalKeys<
       PropsForRemoteComponent<Type>,
       [
-        PropsForRemoteComponent<Type>?,
-        Iterable<
+        (PropsForRemoteComponent<Type> | null)?,
+        MaybeArray<
           AllowedChildren<
             AllowedChildrenTypes,
             RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
             true
           >
         >?,
+        ...AllowedChildren<
+          AllowedChildrenTypes,
+          RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
+          true
+        >[]
       ],
       [
         PropsForRemoteComponent<Type>,
-        Iterable<
+        MaybeArray<
           AllowedChildren<
             AllowedChildrenTypes,
             RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
             true
           >
         >?,
+        ...AllowedChildren<
+          AllowedChildrenTypes,
+          RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
+          true
+        >[]
       ]
     >
   ): RemoteComponent<Type, RemoteRoot<AllowedComponents, AllowedChildrenTypes>>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -80,8 +80,6 @@ type AllowedTextChildren<
   AllowString extends boolean = false
 > = AllowString extends true ? RemoteText<Root> | string : RemoteText<Root>;
 
-type MaybeArray<T> = T | T[];
-
 export interface RemoteRoot<
   AllowedComponents extends RemoteComponentType<
     string,
@@ -121,36 +119,38 @@ export interface RemoteRoot<
     type: Type,
     ...rest: IfAllOptionalKeys<
       PropsForRemoteComponent<Type>,
-      [
-        (PropsForRemoteComponent<Type> | null)?,
-        MaybeArray<
+      | [
+          (PropsForRemoteComponent<Type> | null)?,
+          ...AllowedChildren<
+            AllowedChildrenTypes,
+            RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
+            true
+          >[]
+        ]
+      | [
+          (PropsForRemoteComponent<Type> | null)?,
           AllowedChildren<
             AllowedChildrenTypes,
             RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
             true
-          >
-        >?,
-        ...AllowedChildren<
-          AllowedChildrenTypes,
-          RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
-          true
-        >[]
-      ],
-      [
-        PropsForRemoteComponent<Type>,
-        MaybeArray<
+          >[]?,
+        ],
+      | [
+          PropsForRemoteComponent<Type>,
+          ...AllowedChildren<
+            AllowedChildrenTypes,
+            RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
+            true
+          >[]
+        ]
+      | [
+          PropsForRemoteComponent<Type>,
           AllowedChildren<
             AllowedChildrenTypes,
             RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
             true
-          >
-        >?,
-        ...AllowedChildren<
-          AllowedChildrenTypes,
-          RemoteRoot<AllowedComponents, AllowedChildrenTypes>,
-          true
-        >[]
-      ]
+          >[]?,
+        ]
     >
   ): RemoteComponent<Type, RemoteRoot<AllowedComponents, AllowedChildrenTypes>>;
   createText(


### PR DESCRIPTION
While working on some examples using raw remote-ui objects, I found it annoying that I always had to supply initial children as an array, even if there was only one. This PR changes `RemoteRoot#createComponent` to accept children more flexibly; they can either be provided directly, in the 3rd–nth positional argument spots, or provided as an array in the 3rd positional argument.