### PR TITLE
More flexible htm integration

### DIFF
--- a/packages/htm/README.md
+++ b/packages/htm/README.md
@@ -37,9 +37,11 @@ This library only helps you create the initial structure of remote components. A
 `htm` supports [many handy syntax features](https://github.com/developit/htm#syntax-like-jsx-but-also-lit). Notably, if you have external definitions of the remote components available in your system, you can interpolate them as the type name within your markup.
 
 ```tsx
+import {createRemoteRoot} from '@remote-ui/core';
 import {createRender, append} from '@remote-ui/htm';
 import {BlockStack, Button, Text} from 'my-remote-components';
 
+const root = createRemoteRoot(() => {});
 const ui = createRender(root);
 const stack = root.createComponent(BlockStack);
 

--- a/packages/htm/README.md
+++ b/packages/htm/README.md
@@ -18,7 +18,7 @@ npm install @remote-ui/htm --save
 
 ## Usage
 
-`@remote-ui/htm` provides two functions. The first, `createRender`, is a factory function that takes a [`@remote-ui/core` `RemoteRoot`](../core#remoteroot), and returns a [tagged template](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates). This tagged template binds the main function from the `htm` library into creating a tree of `@remote-ui/core` `RemoteComponent` and `RemoteText` objects. `append`, is a helper to call `appendChild()` on a `RemoteRoot` or `RemoteComponent` for each node in the tree returned by the tagged template.
+`@remote-ui/htm` provides two functions. The first, `createRender`, is a factory function that takes a [`@remote-ui/core` `RemoteRoot`](../core#remoteroot), and returns a [tagged template](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates). This tagged template binds the main function from the `htm` library into creating a tree of `@remote-ui/core` `RemoteComponent` and `RemoteText` objects. The second function, `append`, is a helper to call `appendChild()` on a `RemoteRoot` or `RemoteComponent` for each node in the tree returned by the tagged template.
 
 ```ts
 import {createRemoteRoot} from '@remote-ui/core';

--- a/packages/htm/README.md
+++ b/packages/htm/README.md
@@ -29,7 +29,7 @@ const ui = createRender(root);
 
 const onPress = () => {};
 
-append(root, ui`<Button primary onPress=${onPress}>Submit</Button>`);
+append(ui`<Button primary onPress=${onPress}>Submit</Button>`, root);
 ```
 
 This library only helps you create the initial structure of remote components. Any subsequent updates to that structure (for example, responding to a button press by changing its content) would be performed with the [`RemoteRoot` and `RemoteComponent` APIs](../core).
@@ -41,14 +41,13 @@ import {createRender, append} from '@remote-ui/htm';
 import {BlockStack, Button, Text} from 'my-remote-components';
 
 const ui = createRender(root);
+const stack = root.createComponent(BlockStack);
 
 append(
-  root,
   ui`
-    <${BlockStack} spacing="tight">
-      <${Button} onPress=${() => console.log('Pressed!')}>Submit<//>
-      <${Text} subdued>You’ll have a chance to review your purchase<//>
-    <//>
+    <${Button} onPress=${() => console.log('Pressed!')}>Submit<//>
+    <${Text} subdued>You’ll have a chance to review your purchase<//>
   `,
+  stack,
 );
 ```

--- a/packages/htm/README.md
+++ b/packages/htm/README.md
@@ -18,18 +18,18 @@ npm install @remote-ui/htm --save
 
 ## Usage
 
-`@remote-ui/htm` provides two functions. The first, `createRender`, is a factory function that takes a [`@remote-ui/core` `RemoteRoot`](../core#remoteroot), and returns a [tagged template](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates). This tagged template binds the main function from the `htm` library into creating a tree of `@remote-ui/core` `RemoteComponent` and `RemoteText` objects. The second function, `append`, is a helper to call `appendChild()` on a `RemoteRoot` or `RemoteComponent` for each node in the tree returned by the tagged template.
+`@remote-ui/htm` provides two functions. The first, `createHtm`, is a factory function that takes a [`@remote-ui/core` `RemoteRoot`](../core#remoteroot), and returns a [tagged template](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates). This tagged template binds the main function from the `htm` library into creating a tree of `@remote-ui/core` `RemoteComponent` and `RemoteText` objects. The second function, `append`, is a helper to call `appendChild()` on a `RemoteRoot` or `RemoteComponent` for each node in the tree returned by the tagged template.
 
 ```ts
 import {createRemoteRoot} from '@remote-ui/core';
-import {createRender, append} from '@remote-ui/htm';
+import {createHtm, append} from '@remote-ui/htm';
 
 const root = createRemoteRoot(() => {});
-const ui = createRender(root);
+const htm = createHtm(root);
 
 const onPress = () => {};
 
-append(ui`<Button primary onPress=${onPress}>Submit</Button>`, root);
+append(htm`<Button primary onPress=${onPress}>Submit</Button>`, root);
 ```
 
 This library only helps you create the initial structure of remote components. Any subsequent updates to that structure (for example, responding to a button press by changing its content) would be performed with the [`RemoteRoot` and `RemoteComponent` APIs](../core).
@@ -38,15 +38,15 @@ This library only helps you create the initial structure of remote components. A
 
 ```tsx
 import {createRemoteRoot} from '@remote-ui/core';
-import {createRender, append} from '@remote-ui/htm';
+import {createHtm, append} from '@remote-ui/htm';
 import {BlockStack, Button, Text} from 'my-remote-components';
 
 const root = createRemoteRoot(() => {});
-const ui = createRender(root);
+const htm = createHtm(root);
 const stack = root.createComponent(BlockStack);
 
 append(
-  ui`
+  htm`
     <${Button} onPress=${() => console.log('Pressed!')}>Submit<//>
     <${Text} subdued>You’ll have a chance to review your purchase<//>
   `,

--- a/packages/htm/README.md
+++ b/packages/htm/README.md
@@ -18,17 +18,18 @@ npm install @remote-ui/htm --save
 
 ## Usage
 
-`@remote-ui/htm` provides two functions. The first, `htm`, is a [tagged template](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates), which binds the main function from the `htm` library into a basic object structure. `render`, the second function exported from this library, takes this generated structure and a [`@remote-ui/core` `RemoteRoot`](../core#remoteroot), and appends all of the resulting components into that root.
+`@remote-ui/htm` provides two functions. The first, `createRender`, is a factory function that takes a [`@remote-ui/core` `RemoteRoot`](../core#remoteroot), and returns a [tagged template](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates). This tagged template binds the main function from the `htm` library into creating a tree of `@remote-ui/core` `RemoteComponent` and `RemoteText` objects. `append`, is a helper to call `appendChild()` on a `RemoteRoot` or `RemoteComponent` for each node in the tree returned by the tagged template.
 
 ```ts
 import {createRemoteRoot} from '@remote-ui/core';
-import {htm, render} from '@remote-ui/htm';
+import {createRender, append} from '@remote-ui/htm';
 
 const root = createRemoteRoot(() => {});
+const ui = createRender(root);
+
 const onPress = () => {};
 
-render(htm`<Button primary onPress=${onPress}>Submit</Button>`, root);
-root.mount();
+append(root, ui`<Button primary onPress=${onPress}>Submit</Button>`);
 ```
 
 This library only helps you create the initial structure of remote components. Any subsequent updates to that structure (for example, responding to a button press by changing its content) would be performed with the [`RemoteRoot` and `RemoteComponent` APIs](../core).
@@ -36,16 +37,18 @@ This library only helps you create the initial structure of remote components. A
 `htm` supports [many handy syntax features](https://github.com/developit/htm#syntax-like-jsx-but-also-lit). Notably, if you have external definitions of the remote components available in your system, you can interpolate them as the type name within your markup.
 
 ```tsx
-import {htm, render} from '@remote-ui/htm';
+import {createRender, append} from '@remote-ui/htm';
 import {BlockStack, Button, Text} from 'my-remote-components';
 
-render(
-  htm`
+const ui = createRender(root);
+
+append(
+  root,
+  ui`
     <${BlockStack} spacing="tight">
       <${Button} onPress=${() => console.log('Pressed!')}>Submit<//>
       <${Text} subdued>You’ll have a chance to review your purchase<//>
     <//>
   `,
-  root,
 );
 ```

--- a/packages/htm/src/render.test.ts
+++ b/packages/htm/src/render.test.ts
@@ -28,4 +28,28 @@ describe('htm', () => {
       (root.children[0] as RemoteComponent<any, any>).children[0],
     ).toStrictEqual(expect.objectContaining({text: content}));
   });
+
+  it('can append to RemoteComponents', () => {
+    const root = createRemoteRoot(() => {});
+    const ui = createRender(root);
+
+    const onPress = jest.fn();
+    const content = 'Buy me!';
+
+    const Stack = createRemoteComponent('Stack');
+    const stack = root.createComponent(Stack);
+
+    append(ui`<${Button} onPress=${onPress}>${content}<//>`, stack);
+
+    expect(stack.children).toHaveLength(1);
+    expect(stack.children[0]).toStrictEqual(
+      expect.objectContaining({
+        type: Button,
+        props: {onPress},
+      }),
+    );
+    expect(
+      (stack.children[0] as RemoteComponent<any, any>).children[0],
+    ).toStrictEqual(expect.objectContaining({text: content}));
+  });
 });

--- a/packages/htm/src/render.test.ts
+++ b/packages/htm/src/render.test.ts
@@ -3,19 +3,19 @@ import {
   createRemoteComponent,
   RemoteComponent,
 } from '@remote-ui/core';
-import {createRender, append} from './render';
+import {createHtm, append} from './render';
 
 const Button = createRemoteComponent('Button');
 
 describe('htm', () => {
   it('converts htm into RemoteRoot operations', () => {
     const root = createRemoteRoot(() => {});
-    const ui = createRender(root);
+    const htm = createHtm(root);
 
     const onPress = jest.fn();
     const content = 'Buy me!';
 
-    append(ui`<${Button} onPress=${onPress}>${content}<//>`, root);
+    append(htm`<${Button} onPress=${onPress}>${content}<//>`, root);
 
     expect(root.children).toHaveLength(1);
     expect(root.children[0]).toStrictEqual(
@@ -31,7 +31,7 @@ describe('htm', () => {
 
   it('can append to RemoteComponents', () => {
     const root = createRemoteRoot(() => {});
-    const ui = createRender(root);
+    const htm = createHtm(root);
 
     const onPress = jest.fn();
     const content = 'Buy me!';
@@ -39,7 +39,7 @@ describe('htm', () => {
     const Stack = createRemoteComponent('Stack');
     const stack = root.createComponent(Stack);
 
-    append(ui`<${Button} onPress=${onPress}>${content}<//>`, stack);
+    append(htm`<${Button} onPress=${onPress}>${content}<//>`, stack);
 
     expect(stack.children).toHaveLength(1);
     expect(stack.children[0]).toStrictEqual(

--- a/packages/htm/src/render.test.ts
+++ b/packages/htm/src/render.test.ts
@@ -3,17 +3,19 @@ import {
   createRemoteComponent,
   RemoteComponent,
 } from '@remote-ui/core';
-import {htm, render} from './render';
+import {createRender, append} from './render';
 
 const Button = createRemoteComponent('Button');
 
 describe('htm', () => {
   it('converts htm into RemoteRoot operations', () => {
     const root = createRemoteRoot(() => {});
-    const onPress = jest.fn();
-    const content = 'Buy now';
+    const ui = createRender(root);
 
-    render(htm`<${Button} onPress=${onPress}>${content}<//>`, root);
+    const onPress = jest.fn();
+    const content = 'Buy me!';
+
+    append(root, ui`<${Button} onPress=${onPress}>${content}<//>`);
 
     expect(root.children).toHaveLength(1);
     expect(root.children[0]).toStrictEqual(

--- a/packages/htm/src/render.test.ts
+++ b/packages/htm/src/render.test.ts
@@ -15,7 +15,7 @@ describe('htm', () => {
     const onPress = jest.fn();
     const content = 'Buy me!';
 
-    append(root, ui`<${Button} onPress=${onPress}>${content}<//>`);
+    append(ui`<${Button} onPress=${onPress}>${content}<//>`, root);
 
     expect(root.children).toHaveLength(1);
     expect(root.children[0]).toStrictEqual(

--- a/packages/htm/src/render.ts
+++ b/packages/htm/src/render.ts
@@ -2,7 +2,7 @@ import baseHtm from 'htm';
 import {isRemoteComponent} from '@remote-ui/core';
 import type {RemoteRoot, RemoteComponent} from '@remote-ui/core';
 
-export function createRender(root: RemoteRoot<any, any>) {
+export function createHtm(root: RemoteRoot<any, any>) {
   return baseHtm.bind((type, props, ...children) => {
     const normalizedChildren: (string | RemoteComponent<any, any>)[] = [];
 
@@ -25,7 +25,7 @@ export function createRender(root: RemoteRoot<any, any>) {
 }
 
 export function append(
-  tree: ReturnType<ReturnType<typeof createRender>>,
+  tree: ReturnType<ReturnType<typeof createHtm>>,
   parent: RemoteRoot<any, any> | RemoteComponent<any, any>,
 ) {
   if (Array.isArray(tree)) {

--- a/packages/htm/src/render.ts
+++ b/packages/htm/src/render.ts
@@ -1,65 +1,38 @@
 import baseHtm from 'htm';
+import {isRemoteComponent} from '@remote-ui/core';
 import type {RemoteRoot, RemoteComponent} from '@remote-ui/core';
 
-interface Element {
-  type: string;
-  props: Record<string, any>;
-  children: (string | Element)[];
+export function createRender(root: RemoteRoot<any, any>) {
+  return baseHtm.bind((type, props, ...children) => {
+    const normalizedChildren: (string | RemoteComponent<any, any>)[] = [];
+
+    for (const child of children) {
+      if (child == null || child === false) continue;
+
+      if (typeof child === 'object') {
+        if (!isRemoteComponent(child)) {
+          throw new Error(`Unexpected child: ${JSON.stringify(child)}`);
+        }
+
+        normalizedChildren.push(child);
+      } else {
+        normalizedChildren.push(String(child));
+      }
+    }
+
+    return root.createComponent(type, props, normalizedChildren);
+  });
 }
 
-export const htm = baseHtm.bind<Element>((type, props, ...children) => {
-  if (typeof type !== 'string') {
-    throw new Error(`You can only create components with string names.`);
-  }
-
-  for (const child of children) {
-    if (
-      typeof child !== 'string' &&
-      typeof child !== 'number' &&
-      !isElement(child)
-    ) {
-      throw new Error(`Unexpected child ${JSON.stringify(child)}`);
-    }
-  }
-
-  return {type, props, children};
-});
-
-export function render<Root extends RemoteRoot<any, any>>(
-  tree: ReturnType<typeof htm>,
-  root: Root,
+export function append(
+  parent: RemoteRoot<any, any> | RemoteComponent<any, any>,
+  tree: ReturnType<ReturnType<typeof createRender>>,
 ) {
-  const normalizedTree = Array.isArray(tree) ? tree : [tree];
-  return normalizedTree.map((element) => attach(element, root, root));
-}
-
-function attach<Root extends RemoteRoot<any, any>>(
-  {type, props, children}: Element,
-  to: Root | RemoteComponent<any, any>,
-  root: Root,
-): RemoteComponent<any, Root> {
-  const component = root.createComponent(type, props);
-
-  for (const child of children) {
-    if (typeof child === 'string') {
-      component.appendChild(child);
-    } else if (typeof child === 'number') {
-      component.appendChild(String(child));
-    } else {
-      attach(child, component, root);
+  if (Array.isArray(tree)) {
+    for (const child of tree) {
+      parent.appendChild(child);
     }
+  } else {
+    parent.appendChild(tree);
   }
-
-  to.appendChild(component);
-
-  return component as any;
-}
-
-function isElement(child: unknown): child is Element {
-  return (
-    child != null &&
-    typeof (child as any).type === 'string' &&
-    typeof (child as any).props === 'object' &&
-    Array.isArray((child as any).children)
-  );
 }

--- a/packages/htm/src/render.ts
+++ b/packages/htm/src/render.ts
@@ -25,8 +25,8 @@ export function createRender(root: RemoteRoot<any, any>) {
 }
 
 export function append(
-  parent: RemoteRoot<any, any> | RemoteComponent<any, any>,
   tree: ReturnType<ReturnType<typeof createRender>>,
+  parent: RemoteRoot<any, any> | RemoteComponent<any, any>,
 ) {
   if (Array.isArray(tree)) {
     for (const child of tree) {


### PR DESCRIPTION
This PR totally reworks the `htm` integration for remote-ui. My first stab at this was weird for a few reasons:

1. You could only append the tree created by the `htm` integration to a `RemoteRoot`, not a `RemoteComponent`
1. The tree of objects you got from calling `htm` was not actually a tree of `RemoteComponent`/ `RemoteText`, it was a tree of an intermediate representation that needed the `render()` call to turn them into "real" instances

This PR removes both of these weirdnesses. You now have to create the tagged template function by passing a `RemoteRoot`. This allows the tree created by the tagged template to be real `RemoteComponent` and `RemoteText` objects. I replaced the `render` function with an `append` function that can append the resulting tree to a `RemoteRoot`, or `RemoteComponent`. This makes it much easier to use the `htm` integration to construct just a part of the tree, which makes this well-suited to creating a large, entirely-static subtree while still using the core remote-ui APIs for the more dynamic bits.