### PR TITLE
only run load handler once in frame messenger

### DIFF
--- a/packages/web-workers/src/messenger/iframe/create-messenger.ts
+++ b/packages/web-workers/src/messenger/iframe/create-messenger.ts
@@ -9,14 +9,19 @@ export function createIframeWorkerMessenger(
 
   const iframe = document.createElement('iframe');
   iframe.setAttribute('style', 'display:none;');
-  iframe.addEventListener('load', () => {
+
+  function loadHandler() {
     port1.start();
     iframe.contentWindow!.postMessage(
       {[IFRAME_RUN_IDENTIFIER]: url.href},
       '*',
       [port2],
     );
-  });
+
+    iframe.removeEventListener('load', loadHandler);
+  }
+
+  iframe.addEventListener('load', loadHandler);
 
   prepareIframe(iframe);
   document.body.appendChild(iframe);


### PR DESCRIPTION
An attempt to fix issues like `Port at index 0 is already neutered`

While I could not reproduce the error, [it is reported that Chrome / Safari trigger iframe `onload` mutiple times under some circumstances.](https://stackoverflow.com/questions/10781880/dynamically-created-iframe-triggers-onload-event-twice/15880489#15880489)

If that happens, our code would currently re-use `port2` as transferrable, which can't be done [as the receiving side takes ownership once it's been transferred once.
](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#Syntax:~:text=site.-,transfer)

> Is a sequence of Transferable objects that are transferred with the message. The ownership of these objects is given to the destination side and they are no longer usable on the sending side.

And we didn't want to trigger this multiple times anyways even if possible afaik.


🎩 by building the package and copying and using it in our checkout.