### PR TITLE
Fix hotswap function when updating arrays of different lengths as nested arrays

### DIFF
--- a/packages/core/src/tests/root.test.ts
+++ b/packages/core/src/tests/root.test.ts
@@ -176,6 +176,89 @@ describe('root', () => {
       expect(funcOne).not.toHaveBeenCalled();
       expect(funcTwo).toHaveBeenCalled();
     });
+
+    it('hot-swaps function props for arrays when the length increases', () => {
+      const firstActionFuncOne = jest.fn();
+      const firstActionFuncTwo = jest.fn();
+      const secondActionFunc = jest.fn();
+      const receiver = createDelayedReceiver();
+
+      const root = createRemoteRoot(receiver.receive);
+      const modal = root.createComponent('Modal', {
+        secondaryActions: [{onAction: firstActionFuncOne}],
+      });
+
+      root.appendChild(modal);
+      root.mount();
+
+      modal.updateProps({
+        secondaryActions: [
+          {onAction: firstActionFuncTwo},
+          {onAction: secondActionFunc},
+        ],
+      });
+
+      receiver.flush();
+
+      const {
+        secondaryActions: [firstAction, secondAction],
+      } = (receiver.children[0] as any).props;
+
+      firstAction.onAction();
+      secondAction.onAction();
+
+      expect(firstActionFuncOne).not.toHaveBeenCalled();
+      expect(firstActionFuncTwo).toHaveBeenCalled();
+      expect(secondActionFunc).toHaveBeenCalled();
+    });
+
+    it('hot-swaps function props for nested arrays', () => {
+      const firstActionFuncOne = jest.fn();
+      const firstActionFuncTwo = jest.fn();
+      const secondActionFuncOne = jest.fn();
+      const receiver = createDelayedReceiver();
+
+      const root = createRemoteRoot(receiver.receive);
+      const modal = root.createComponent('Modal', {
+        actionGroups: [
+          {
+            actions: [{onAction: firstActionFuncOne}],
+          },
+        ],
+      });
+
+      root.appendChild(modal);
+      root.mount();
+
+      modal.updateProps({
+        actionGroups: [
+          {
+            actions: [
+              {onAction: firstActionFuncTwo},
+              {onAction: secondActionFuncOne},
+            ],
+          },
+        ],
+      });
+
+      receiver.flush();
+
+      const {
+        actionGroups: [
+          {
+            actions: [actionOne, actionTwo],
+          },
+        ],
+      } = (receiver.children[0] as any).props;
+
+      actionOne.onAction();
+      actionTwo.onAction();
+
+      expect(firstActionFuncOne).not.toHaveBeenCalled();
+      expect(firstActionFuncTwo).toHaveBeenCalled();
+
+      expect(secondActionFuncOne).toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
Related to https://github.com/Shopify/app-extension-libs/issues/1142

This fix is really just 2 lines:

![image](https://user-images.githubusercontent.com/29458473/98173043-6a3f0080-1ec0-11eb-8e37-684b33b07d75.png)

However, I refactored it a bit so that the code is easier to debug in the future. I think it's slightly easier to read now with less nested conditionals and smaller functions for handling objects and arrays.

### Tophat
1. In https://github.com/shopify/app-extension-libs, do
```
dev up
```
2. In this repo, do 
```
yarn && yarn build && cp -R ./packages/* ../app-extension-libs/node_modules/@remote-ui
```
- In https://github.com/shopify/app-extension-libs, do
```
dev up
```
3. Navigate to https://argo-playground.myshopify.io/components-list 
4. Verify that a modal can be opened with multiple secondary actions
![image](https://user-images.githubusercontent.com/29458473/98172873-1c29fd00-1ec0-11eb-8289-974e2ca22a31.png)