### PR TITLE
Core updates

### DIFF
--- a/packages/core/src/receiver.ts
+++ b/packages/core/src/receiver.ts
@@ -157,6 +157,10 @@ export class RemoteReceiver {
     };
   }
 
+  flush() {
+    return this.timeout ?? Promise.resolve();
+  }
+
   private enqueueUpdate(attached: Attachable) {
     this.timeout =
       this.timeout ??

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -80,6 +80,13 @@ type AllowedTextChildren<
   AllowString extends boolean = false
 > = AllowString extends true ? RemoteText<Root> | string : RemoteText<Root>;
 
+export interface RemoteRootOptions<
+  AllowedComponents extends RemoteComponentType<string, any>
+> {
+  readonly strict?: boolean;
+  readonly components?: readonly AllowedComponents[];
+}
+
 export interface RemoteRoot<
   AllowedComponents extends RemoteComponentType<
     string,
@@ -92,6 +99,7 @@ export interface RemoteRoot<
     AllowedChildrenTypes,
     RemoteRoot<AllowedComponents, AllowedChildrenTypes>
   >[];
+  readonly options: RemoteRootOptions<AllowedComponents>;
   appendChild(
     child: AllowedChildren<
       AllowedChildrenTypes,
@@ -207,13 +215,16 @@ export type RemoteComponentSerialization<
     any
   >
 > = {
-  -readonly [K in 'id' | 'type' | 'props']: RemoteComponent<Type, any>[K];
+  -readonly [K in 'id' | 'type' | 'kind' | 'props']: RemoteComponent<
+    Type,
+    any
+  >[K];
 } & {
   children: (RemoteComponentSerialization | RemoteTextSerialization)[];
 };
 
 export type RemoteTextSerialization = {
-  -readonly [K in 'id' | 'text']: RemoteText<any>[K];
+  -readonly [K in 'id' | 'text' | 'kind']: RemoteText<any>[K];
 };
 
 export type Serialized<T> = T extends RemoteComponent<infer Type, any>

--- a/packages/core/src/utilities.ts
+++ b/packages/core/src/utilities.ts
@@ -1,21 +1,16 @@
 import type {RemoteComponentType} from '@remote-ui/types';
-import type {
-  RemoteRoot,
-  RemoteComponent,
-  RemoteText,
-  RemoteChild,
-} from './types';
+import type {RemoteRoot, RemoteComponent, RemoteText} from './types';
 import {KIND_COMPONENT, KIND_TEXT} from './types';
 
 export function isRemoteComponent<
   Type extends RemoteComponentType<string, any, any> = any,
   Root extends RemoteRoot<any, any> = RemoteRoot<any, any>
->(child: RemoteChild<Root>): child is RemoteComponent<Type, Root> {
-  return child.kind === KIND_COMPONENT;
+>(child: unknown): child is RemoteComponent<Type, Root> {
+  return child != null && (child as any).kind === KIND_COMPONENT;
 }
 
 export function isRemoteText<
   Root extends RemoteRoot<any, any> = RemoteRoot<any, any>
->(child: RemoteChild<Root>): child is RemoteText<Root> {
-  return child.kind === KIND_TEXT;
+>(child: unknown): child is RemoteText<Root> {
+  return child != null && (child as any).kind === KIND_TEXT;
 }

--- a/packages/web-workers/src/babel-plugin.ts
+++ b/packages/web-workers/src/babel-plugin.ts
@@ -75,7 +75,10 @@ export default function workerBabelPlugin({
         }
 
         for (const specifier of importDeclaration.get('specifiers')) {
-          if (!specifier.isImportSpecifier()) {
+          if (
+            !specifier.isImportSpecifier() ||
+            specifier.node.imported.type !== 'Identifier'
+          ) {
             continue;
           }
 


### PR DESCRIPTION
Adds a few new features/ tweaks to the core library to support the forthcoming Vue library:

1. Adds `flush()` to `RemoteReceiver` to easily place code after all the current remote operations are complete.
1. Exposes `options` on `RemoteRoot` so that other libraries can see the available components.
1. Adds `kind` to the serialization of remote components and text for easier disambiguation between them.
1. More flexible utility functions for checking whether a value is a remote text/ component.