### PR TITLE
React updates

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
     "@remote-ui/core": "^1.5.4",
     "@remote-ui/rpc": "^1.0.11",
     "@remote-ui/web-workers": "^1.2.7",
-    "@types/react": ">=16.8.0 <17.0.0",
-    "react-reconciler": "^0.25.0"
+    "@types/react": ">=16.8.0 <18.0.0",
+    "react-reconciler": ">=0.25.0 <1.0.0"
   }
 }

--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -6,7 +6,7 @@ import type {
   RemoteComponent as RemoteComponentDescription,
 } from '@remote-ui/core';
 
-import {Controller} from './controller';
+import type {Controller} from './controller';
 import {RemoteText} from './RemoteText';
 import {useAttached} from './hooks';
 

--- a/packages/react/src/host/RemoteRenderer.tsx
+++ b/packages/react/src/host/RemoteRenderer.tsx
@@ -1,5 +1,5 @@
 import React, {memo, Fragment, createElement} from 'react';
-import type {RemoteReceiver} from '@remote-ui/core';
+import {KIND_COMPONENT, KIND_TEXT, RemoteReceiver} from '@remote-ui/core';
 
 import type {Controller} from './controller';
 import {useAttached} from './hooks';
@@ -17,18 +17,23 @@ export const RemoteRenderer = memo(({controller, receiver}: Props) => {
   return createElement(
     Fragment,
     {},
-    ...children.map((child) =>
-      'type' in child ? (
-        <RemoteComponent
-          key={child.id}
-          component={child}
-          receiver={receiver}
-          controller={controller}
-          __type__={(controller.get(child.type) as any)?.__type__}
-        />
-      ) : (
-        <RemoteText key={child.id} text={child} receiver={receiver} />
-      ),
-    ),
+    ...children.map((child) => {
+      switch (child.kind) {
+        case KIND_COMPONENT:
+          return (
+            <RemoteComponent
+              key={child.id}
+              component={child}
+              receiver={receiver}
+              controller={controller}
+              __type__={(controller.get(child.type) as any)?.__type__}
+            />
+          );
+        case KIND_TEXT:
+          return <RemoteText key={child.id} text={child} receiver={receiver} />;
+        default:
+          return null;
+      }
+    }),
   );
 });

--- a/packages/react/src/host/RemoteRenderer.tsx
+++ b/packages/react/src/host/RemoteRenderer.tsx
@@ -1,19 +1,17 @@
-import React, {memo, useMemo, Fragment, createElement} from 'react';
+import React, {memo, Fragment, createElement} from 'react';
 import type {RemoteReceiver} from '@remote-ui/core';
 
-import {Controller} from './controller';
-import type {ComponentMapping} from './controller';
+import type {Controller} from './controller';
 import {useAttached} from './hooks';
 import {RemoteText} from './RemoteText';
 import {RemoteComponent} from './RemoteComponent';
 
 interface Props {
   receiver: RemoteReceiver;
-  components: ComponentMapping;
+  controller: Controller;
 }
 
-export const RemoteRenderer = memo(({components, receiver}: Props) => {
-  const controller = useMemo(() => new Controller(components), [components]);
+export const RemoteRenderer = memo(({controller, receiver}: Props) => {
   const {children} = useAttached(receiver, receiver.root)!;
 
   return createElement(

--- a/packages/react/src/host/controller.tsx
+++ b/packages/react/src/host/controller.tsx
@@ -5,17 +5,20 @@ export interface ComponentMapping {
   [key: string]: ComponentType<any>;
 }
 
-export class Controller<ComponentConfig extends ComponentMapping = {}> {
-  private readonly registry: Map<string, ComponentType<any>>;
+export interface Controller {
+  get(type: string | RemoteComponentType<string, any, any>): ComponentType<any>;
+}
 
-  constructor(public readonly components: ComponentConfig = {} as any) {
-    this.registry = new Map(Object.entries(components));
-  }
+export function createController(components: ComponentMapping): Controller {
+  const registry = new Map(Object.entries(components));
 
-  get(type: string | RemoteComponentType<string, any, any>) {
-    if (!this.registry.has(type as any)) {
-      throw new Error(`Unknown component: ${type}`);
-    }
-    return this.registry.get(type as any);
-  }
+  return {
+    get(type) {
+      const value = registry.get(type as any);
+      if (value == null) {
+        throw new Error(`Unknown component: ${type}`);
+      }
+      return value;
+    },
+  };
 }

--- a/packages/react/src/host/index.ts
+++ b/packages/react/src/host/index.ts
@@ -1,6 +1,8 @@
 export {RemoteReceiver} from '@remote-ui/core';
 
-export {RemoteRenderer} from './Renderer';
+export {RemoteRenderer} from './RemoteRenderer';
+export {createController} from './controller';
+export type {Controller, ComponentMapping} from './controller';
 export type {
   ReactPropsFromRemoteComponentType,
   ReactComponentTypeFromRemoteComponentType,

--- a/packages/react/src/reconciler.ts
+++ b/packages/react/src/reconciler.ts
@@ -69,7 +69,7 @@ const reconciler = reactReconciler<
     let needsUpdate = false;
 
     for (const key in oldProps) {
-      if (!Reflect.has(oldProps, key) || key === 'children') {
+      if (!has(oldProps, key) || key === 'children') {
         continue;
       }
 
@@ -94,7 +94,7 @@ const reconciler = reactReconciler<
     }
 
     for (const key in newProps) {
-      if (!Reflect.has(newProps, key) || key === 'children') {
+      if (!has(newProps, key) || key === 'children') {
         continue;
       }
 
@@ -123,16 +123,16 @@ const reconciler = reactReconciler<
 
   // Update children
   appendInitialChild(parent, child) {
-    (parent as any).appendChild(child);
+    parent.appendChild(child);
   },
   appendChild(parent, child) {
-    (parent as any).appendChild(child);
+    parent.appendChild(child);
   },
   insertBefore(parent, newChild, beforeChild) {
-    (parent as any).insertChildBefore(newChild, beforeChild);
+    parent.insertChildBefore(newChild, beforeChild);
   },
   removeChild(parent, child) {
-    (parent as any).removeChild(child);
+    parent.removeChild(child);
   },
 
   // Deferred callbacks
@@ -165,5 +165,10 @@ const reconciler = reactReconciler<
   resetAfterCommit() {},
   commitMount() {},
 });
+
+const {hasOwnProperty} = {};
+function has(object: object, property: string | number | symbol) {
+  return hasOwnProperty.call(object, property);
+}
 
 export default reconciler;

--- a/packages/react/src/tests/e2e.test.tsx
+++ b/packages/react/src/tests/e2e.test.tsx
@@ -4,7 +4,7 @@ import {act as domAct} from 'react-dom/test-utils';
 
 import {createRemoteRoot, RemoteReceiver} from '@remote-ui/core';
 
-import {RemoteRenderer} from '../host';
+import {RemoteRenderer, createController} from '../host';
 import {
   render,
   createRemoteReactComponent,
@@ -67,13 +67,10 @@ describe('@remote-ui/react', () => {
       return <RemoteHelloWorld name={name} />;
     }
 
+    const controller = createController({HelloWorld: HostHelloWorld});
+
     function HostApp() {
-      return (
-        <RemoteRenderer
-          components={{HelloWorld: HostHelloWorld}}
-          receiver={receiver}
-        />
-      );
+      return <RemoteRenderer controller={controller} receiver={receiver} />;
     }
 
     domAct(() => {
@@ -100,15 +97,12 @@ describe('@remote-ui/react', () => {
       return <RemoteWithPerson run={spy} />;
     }
 
+    const controller = createController({
+      WithPerson: HostWithPerson,
+    });
+
     function HostApp() {
-      return (
-        <RemoteRenderer
-          components={{
-            WithPerson: HostWithPerson,
-          }}
-          receiver={receiver}
-        />
-      );
+      return <RemoteRenderer controller={controller} receiver={receiver} />;
     }
 
     domAct(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,10 +2750,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.8.0 <17.0.0":
-  version "16.9.49"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
-  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
+"@types/react@*", "@types/react@>=16.8.0 <18.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
+  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -9201,7 +9201,7 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-reconciler@^0.25.0, react-reconciler@^0.25.1:
+"react-reconciler@>=0.25.0 <1.0.0", react-reconciler@^0.25.1:
   version "0.25.1"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.25.1.tgz#f9814d59d115e1210762287ce987801529363aaa"
   integrity sha512-R5UwsIvRcSs3w8n9k3tBoTtUHdVhu9u84EG7E5M0Jk9F5i6DA1pQzPfUZd6opYWGy56MJOtV3VADzy6DRwYDjw==
@@ -9722,6 +9722,14 @@ scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
+  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
This PR makes a few changes to the React library in preparation for the Vue library:

1. Reworks the `components` prop to instead accept a `Controller` directly, which avoids some potential confusion about when that object is recreated
1. Looser version constraints on React things
1. Other small updates and documentation fixes