### PR TITLE
Use chunkFilename as worker filename when available

### DIFF
--- a/packages/web-workers/src/webpack-parts/loader.ts
+++ b/packages/web-workers/src/webpack-parts/loader.ts
@@ -89,13 +89,11 @@ export function pitch(
     );
   }
 
+  const {filename, chunkFilename} = compiler.options.output!;
+
   const workerOptions = {
-    filename: addWorkerSubExtension(
-      compiler.options.output!.filename as string,
-    ),
-    chunkFilename: addWorkerSubExtension(
-      compiler.options.output!.chunkFilename!,
-    ),
+    filename: addWorkerSubExtension((chunkFilename || filename) as string),
+    chunkFilename: addWorkerSubExtension(chunkFilename as string),
     globalObject: (plugin && plugin.options.globalObject) || 'self',
   };
 

--- a/packages/web-workers/src/webpack-parts/loader.ts
+++ b/packages/web-workers/src/webpack-parts/loader.ts
@@ -89,11 +89,13 @@ export function pitch(
     );
   }
 
-  const {filename, chunkFilename} = compiler.options.output!;
-
   const workerOptions = {
-    filename: addWorkerSubExtension((chunkFilename || filename) as string),
-    chunkFilename: addWorkerSubExtension(chunkFilename as string),
+    filename: addWorkerSubExtension(
+      plugin.options.filename || (compiler.options.output!.filename as string),
+    ),
+    chunkFilename: addWorkerSubExtension(
+      compiler.options.output!.chunkFilename!,
+    ),
     globalObject: (plugin && plugin.options.globalObject) || 'self',
   };
 
@@ -164,7 +166,7 @@ export function pitch(
 function addWorkerSubExtension(file: string) {
   return file.includes('[name]')
     ? file.replace(/\.([a-z]+)$/i, '.worker.$1')
-    : `${file.split('/').slice(0, -1).join('/')}/[name].worker.js`;
+    : file.replace(/\.([a-z]+)$/i, '.[name].worker.$1');
 }
 
 const loader = {

--- a/packages/web-workers/src/webpack-parts/loader.ts
+++ b/packages/web-workers/src/webpack-parts/loader.ts
@@ -90,9 +90,9 @@ export function pitch(
   }
 
   const workerOptions = {
-    filename: addWorkerSubExtension(
-      plugin.options.filename || (compiler.options.output!.filename as string),
-    ),
+    filename:
+      plugin.options.filename ??
+      addWorkerSubExtension(compiler.options.output!.filename as string),
     chunkFilename: addWorkerSubExtension(
       compiler.options.output!.chunkFilename!,
     ),

--- a/packages/web-workers/src/webpack-parts/plugin.ts
+++ b/packages/web-workers/src/webpack-parts/plugin.ts
@@ -7,6 +7,7 @@ type Plugin = import('webpack').Plugin;
 interface Options {
   globalObject?: string;
   plugins?: readonly Plugin[];
+  filename?: string;
 }
 
 export class WebWorkerPlugin implements Plugin {


### PR DESCRIPTION
This PR uses chunkFilename as worker filename when available. It's not possible to add unsupported key to Webpack config (ex: workerFilename) because Webpack validates all the keys. So, I think reusing same chunkFilename for worker file makes sense. 

Resolve https://github.com/Shopify/remote-ui/issues/56

## How to test?
- Run `yarn build`
- Copy all packages to Web via `cp -R ./packages/* ../web/node_modules/@remote-ui/`
- In Web, do 
  + In `scripts/builder/build-argo-host/index.ts`, add this to plugins block
```
        new WebWorkerPlugin({
          filename: isProduction ? '[name].[contenthash].worker.js' : undefined,
        }),
```
  + `IS_CLOUD_ENV=true yarn build:argo-host`
  + Verify that the output file name for worker has content hash.

Note that: running `contenthash` in development mode seems overkill. The webpack task just stops without error and no output in the build folder. 