### PR TITLE
Improve async subscriptions

### DIFF
--- a/packages/async-subscription/CHANGELOG.md
+++ b/packages/async-subscription/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-02-08
+
+### Changed
+
+- **Breaking:** changed all type and function names to be more accurate and to decouple the library from React.
+
 ## [1.0.2] - 2020-06-24
 
 ### Fixed

--- a/packages/async-subscription/README.md
+++ b/packages/async-subscription/README.md
@@ -20,27 +20,29 @@ npm install @remote-ui/async-subscription --save
 
 This library considers three different types of subscriptions:
 
-1. A synchronous subscription (`SyncSubscription`), which allows synchronous access to the current value with `getCurrentValue()`, and allows registering and unregistering a callback synchronously with `subscribe()`. The signature for this function is modelled after the [React `useSubscription()` definition](https://github.com/facebook/react/tree/master/packages/use-subscription) of a subscription.
-1. An asynchronous subscription (`AsyncSubscription`), which provides an `initial` value synchronously, and an asynchronous `subscribe()` function that that can register for all changes to their subscribed value, as documented below.
-1. A stateful asynchronous subscription (`StatefulAsyncSubscription`), which is based on `AsyncSubscription`, but presents the API of a `SyncSubscription`.
+1. A synchronous subscription (`SyncSubscribable`), which allows synchronous access to the current value with the `current` property, and allows registering and registering a callback synchronously with `subscribe()`.
+1. A remote subscription (`RemoteSubscribable`), which provides an `initial` value synchronously, and an asynchronous `subscribe()` function that that can register for all changes to their subscribed value, as documented below.
+1. A stateful remote subscription (`StatefulRemoteSubscribable`), which is based on `RemoteSubscribable`, but presents the API of a `SyncSubscribable`.
 
-When providing a subscription to a remote-ui container, you will generally need the host to convert its `SyncSubscription` into an `AsyncSubscription`, which you can then safely pass to the remote context. Once there, you can use it directly, or wrap it as a `StatefulAsyncSubscription` to continuously provide the most recent value synchronously (rather than merely relying on the initial value, and asynchronously updating it for each subscriber).
+When providing a subscription to a remote-ui container, you will generally need the host to convert its `SyncSubscribable` into an `RemoteSubscribable`, which you can then safely pass to the remote context. Once there, you can use it directly, or wrap it as a `StatefulRemoteSubscribable` to continuously provide the most recent value synchronously (rather than merely relying on the initial value, and asynchronously updating it for each subscriber).
 
 This library provides utilities to do both parts of this job.
 
-### `createAsyncSubscription()`
+### `createRemoteSubscribable()`
 
 This function accepts a synchronous subscription, and returns its asynchronous version.
 
 ```ts
-import {createAsyncSubscription} from '@remote-ui/async-subscription';
+import {createRemoteSubscribable} from '@remote-ui/async-subscription';
 
 const input = document.createElement('input');
 
 // We will create an async subscription for an HTML input’s value. We’ll provide
 // the input’s initial value, and add an event listener for updates.
-const subscription = createAsyncSubscription<string>({
-  getCurrentValue: () => input.value,
+const subscription = createRemoteSubscribable<string>({
+  get current() {
+    return input.value;
+  },
   subscribe(subscriber) {
     function listener(event: Event) {
       subscriber(event.currentTarget.value);
@@ -57,19 +59,22 @@ const subscription = createAsyncSubscription<string>({
 
 This subscription is now “safe” to use in a remote context. Safety here means that the remote context will always be updated as early as possible with the actual current value of the subscription. It does so by returning the current value every time the remote context calls `subscribe()`, which the remote context can then check against its current value. The async subscription will also [`retain`](../rpc#retain) the subscription, and [`release`](../rpc#release) it when unsubscribed.
 
-## `makeStateful()`
+## `makeStatefulSubscribable()`
 
-This function accepts an asynchronous subscription, and returns a “stateful” asynchronous subscription. This type of subscription will immediately subscribe (and update the current value, if it ends up being different after the initial subscription promise resolves), and will continuously reflect the most recent value it finds in its `getCurrentValue()` method. It also retains the subscription.
+This function accepts a remote subscription, and returns a “stateful” remote subscription. This type of subscription will immediately subscribe (and update the current value, if it ends up being different after the initial subscription promise resolves), and will continuously reflect the most recent value it finds in its `getCurrentValue()` method. It also retains the subscription.
 
-The `subscribe()` method behaves as if it were asynchronous (returning a function that can be used to unsubscribe), but this does not remove the “core” listener on the subscription that maintains the stateful value. To permanently destroy the statefulness of the subscription, you can call the `stop()` method on the resulting subscription.
+The `subscribe()` method behaves as if it were synchronous (returning a function that can be used to unsubscribe), but this does not remove the “core” listener on the subscription that maintains the stateful value. To permanently destroy the statefulness of the subscription, you can call the `destroy()` method on the resulting subscription.
 
 ```ts
-import {makeStateful, AsyncSubscription} from '@remote-ui/async-subscription';
+import {
+  makeStatefulSubscribable,
+  RemoteSubscribable,
+} from '@remote-ui/async-subscription';
 
 // In the remote context...
 
-function receiveSubscription(subscription: AsyncSubscription) {
-  const statefulSubscription = makeStateful(subscription);
+function receiveSubscription<T>(subscription: RemoteSubscribable<T>) {
+  const statefulSubscription = makeStatefulSubscribable(subscription);
 
   const unsubscribe = statefulSubscription.subscribe((value) => {
     console.log('New value');

--- a/packages/async-subscription/src/create.ts
+++ b/packages/async-subscription/src/create.ts
@@ -1,10 +1,10 @@
 import {retain, release} from '@remote-ui/rpc';
-import type {SyncSubscription, AsyncSubscription} from './types';
+import type {SyncSubscribable, RemoteSubscribable} from './types';
 
-export function createAsyncSubscription<T>(
-  subscription: SyncSubscription<T>,
-): AsyncSubscription<T> {
-  const initial = subscription.getCurrentValue();
+export function createRemoteSubscribable<T>(
+  subscription: SyncSubscribable<T>,
+): RemoteSubscribable<T> {
+  const initial = subscription.current;
 
   return {
     initial,
@@ -12,7 +12,7 @@ export function createAsyncSubscription<T>(
       retain(subscriber);
 
       const unsubscribe = subscription.subscribe(
-        (value = subscription.getCurrentValue()) => {
+        (value = subscription.current) => {
           subscriber(value);
         },
       );
@@ -22,7 +22,7 @@ export function createAsyncSubscription<T>(
         release(subscriber);
       };
 
-      return [teardown, subscription.getCurrentValue()];
+      return [teardown, subscription.current];
     },
   };
 }

--- a/packages/async-subscription/src/index.ts
+++ b/packages/async-subscription/src/index.ts
@@ -1,7 +1,7 @@
-export {makeStateful} from './stateful';
-export {createAsyncSubscription} from './create';
+export {makeStatefulSubscribable} from './stateful';
+export {createRemoteSubscribable} from './create';
 export type {
-  AsyncSubscription,
-  StatefulAsyncSubscription,
-  SyncSubscription,
+  SyncSubscribable,
+  RemoteSubscribable,
+  StatefulRemoteSubscribable,
 } from './types';

--- a/packages/async-subscription/src/tests/stateful.test.ts
+++ b/packages/async-subscription/src/tests/stateful.test.ts
@@ -1,5 +1,5 @@
-import {makeStateful} from '../stateful';
-import type {AsyncSubscription} from '../types';
+import {makeStatefulSubscribable} from '../stateful';
+import type {RemoteSubscribable} from '../types';
 
 jest.mock('@remote-ui/rpc', () => ({
   retain: jest.fn(),
@@ -11,32 +11,32 @@ const {retain, release} = jest.requireMock('@remote-ui/rpc') as {
   release: jest.Mock;
 };
 
-describe('createAsyncSubscription()', () => {
+describe('makeStatefulSubscribable()', () => {
   beforeEach(() => {
     release.mockReset();
     retain.mockReset();
   });
 
   it('retains the subscription', () => {
-    const subscription = createAsyncSubscription(123);
-    makeStateful(subscription);
+    const subscription = createRemoteSubscribable(123);
+    makeStatefulSubscribable(subscription);
     expect(retain).toHaveBeenCalledWith(subscription);
   });
 
   it('keeps track of the current value', async () => {
-    const subscription = createAsyncSubscription('abc');
-    const statefulSubscription = makeStateful(subscription);
+    const subscription = createRemoteSubscribable('abc');
+    const statefulSubscription = makeStatefulSubscribable(subscription);
     await subscription.resolve();
 
     const newValue = 'xyz';
     subscription.update(newValue);
 
-    expect(statefulSubscription.getCurrentValue()).toBe(newValue);
+    expect(statefulSubscription.current).toBe(newValue);
   });
 
   it('calls subscribers with new values', async () => {
-    const subscription = createAsyncSubscription('abc');
-    const statefulSubscription = makeStateful(subscription);
+    const subscription = createRemoteSubscribable('abc');
+    const statefulSubscription = makeStatefulSubscribable(subscription);
     await subscription.resolve();
 
     const subscriber = jest.fn();
@@ -49,8 +49,8 @@ describe('createAsyncSubscription()', () => {
   });
 
   it('updates the current value when the value has changed before subscription', async () => {
-    const subscription = createAsyncSubscription('abc');
-    const statefulSubscription = makeStateful(subscription);
+    const subscription = createRemoteSubscribable('abc');
+    const statefulSubscription = makeStatefulSubscribable(subscription);
     const subscriber = jest.fn();
     statefulSubscription.subscribe(subscriber);
 
@@ -60,44 +60,44 @@ describe('createAsyncSubscription()', () => {
     await subscription.resolve();
 
     expect(subscriber).toHaveBeenCalledWith(newValue);
-    expect(statefulSubscription.getCurrentValue()).toBe(newValue);
+    expect(statefulSubscription.current).toBe(newValue);
   });
 
   it('releases the subscription when stopped', async () => {
-    const subscription = createAsyncSubscription('abc');
-    const statefulSubscription = makeStateful(subscription);
+    const subscription = createRemoteSubscribable('abc');
+    const statefulSubscription = makeStatefulSubscribable(subscription);
 
     await subscription.resolve();
-    await statefulSubscription.stop();
+    await statefulSubscription.destroy();
 
     expect(release).toHaveBeenCalledWith(subscription);
   });
 
   it('unsubscribes from the subscription on stop, and does not apply any updates', async () => {
-    const subscription = createAsyncSubscription('abc');
-    const statefulSubscription = makeStateful(subscription);
+    const subscription = createRemoteSubscribable('abc');
+    const statefulSubscription = makeStatefulSubscribable(subscription);
     const subscriber = jest.fn();
     statefulSubscription.subscribe(subscriber);
 
     const newValue = 'xyz';
     subscription.update(newValue);
 
-    statefulSubscription.stop();
+    statefulSubscription.destroy();
     await subscription.resolve();
 
     expect(release).toHaveBeenCalledWith(subscription);
     expect(subscriber).not.toHaveBeenCalled();
-    expect(statefulSubscription.getCurrentValue()).not.toBe(newValue);
+    expect(statefulSubscription.current).not.toBe(newValue);
   });
 });
 
-function createAsyncSubscription<T>(
+function createRemoteSubscribable<T>(
   initial: T,
-): AsyncSubscription<T> & {update(value: T): void; resolve(): Promise<void>} {
+): RemoteSubscribable<T> & {update(value: T): void; resolve(): Promise<void>} {
   let current = initial;
   let resolved = false;
   const subscribers = new Set<
-    Parameters<AsyncSubscription<T>['subscribe']>[0]
+    Parameters<RemoteSubscribable<T>['subscribe']>[0]
   >();
   const promises = new Set<Promise<void>>();
 

--- a/packages/async-subscription/src/types.ts
+++ b/packages/async-subscription/src/types.ts
@@ -2,19 +2,18 @@ import type {MaybePromise} from '@remote-ui/rpc';
 
 export type Subscriber<T> = (value: T) => void;
 
-export type AsyncSubscribeResult<T> = [() => void, T];
+export type RemoteSubscribeResult<T> = [() => void, T];
 
-export interface AsyncSubscription<T> {
-  readonly initial: T;
-  subscribe(subscriber: Subscriber<T>): MaybePromise<AsyncSubscribeResult<T>>;
-}
-
-// @see https://github.com/facebook/react/tree/master/packages/use-subscription
-export interface SyncSubscription<T> {
-  getCurrentValue(): T;
+export interface SyncSubscribable<T> {
+  readonly current: T;
   subscribe(subscriber: Subscriber<T>): () => void;
 }
 
-export interface StatefulAsyncSubscription<T> extends SyncSubscription<T> {
-  stop(): Promise<void>;
+export interface RemoteSubscribable<T> {
+  readonly initial: T;
+  subscribe(subscriber: Subscriber<T>): MaybePromise<RemoteSubscribeResult<T>>;
+}
+
+export interface StatefulRemoteSubscribable<T> extends SyncSubscribable<T> {
+  destroy(): Promise<void>;
 }

--- a/packages/mini-react/package.json
+++ b/packages/mini-react/package.json
@@ -43,5 +43,13 @@
     "@quilted/react-testing": "^0.2.3",
     "@remote-ui/core": "^1.6.5",
     "htm": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@remote-ui/async-subscription": "^1.0.17"
+  },
+  "peerDependenciesMeta": {
+    "@remote-ui/async-subscription": {
+      "optional": true
+    }
   }
 }

--- a/packages/mini-react/src/compat/hooks/index.ts
+++ b/packages/mini-react/src/compat/hooks/index.ts
@@ -1,0 +1,1 @@
+export {useRemoteSubscription} from './subscription';

--- a/packages/mini-react/src/compat/hooks/subscription.ts
+++ b/packages/mini-react/src/compat/hooks/subscription.ts
@@ -1,0 +1,47 @@
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import {useState, useEffect, useDebugValue} from '../../hooks';
+
+export function useRemoteSubscription<T>(
+  subscribable: StatefulRemoteSubscribable<T>,
+) {
+  const [state, setState] = useState(() => ({
+    subscribable,
+    value: subscribable.current,
+  }));
+
+  let valueToReturn = state.value;
+
+  if (state.subscribable !== subscribable) {
+    valueToReturn = subscribable.current;
+    setState({subscribable, value: valueToReturn});
+  }
+
+  useDebugValue(valueToReturn);
+
+  useEffect(() => {
+    const unsubscribe = subscribable.subscribe(checkForUpdates);
+
+    checkForUpdates();
+
+    return () => {
+      unsubscribe();
+    };
+
+    function checkForUpdates() {
+      const value = subscribable.current;
+
+      setState((previousState) => {
+        if (
+          previousState.subscribable !== subscribable ||
+          previousState.value === value
+        ) {
+          return previousState;
+        }
+
+        return {...previousState, value};
+      });
+    }
+  }, [subscribable]);
+
+  return valueToReturn;
+}

--- a/packages/mini-react/src/compat/index.ts
+++ b/packages/mini-react/src/compat/index.ts
@@ -34,6 +34,7 @@ import {Children} from './Children';
 import {forwardRef} from './forward-ref';
 import {memo} from './memo';
 import {PureComponent} from './PureComponent';
+import {useRemoteSubscription} from './hooks';
 import {StrictMode} from './StrictMode';
 import {version} from './version';
 import {
@@ -53,6 +54,7 @@ export {
   RemoteReceiver,
   render,
   createRemoteReactComponent,
+  useRemoteSubscription,
   // react compatibility
   version,
   cloneElement,

--- a/packages/mini-react/tsconfig.json
+++ b/packages/mini-react/tsconfig.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "references": [{"path": "../core"}]
+  "references": [{"path": "../core"}, {"path": "../async-subscription"}]
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -175,3 +175,20 @@ This package exports a helper type for extracting information from components cr
   );
   type ButtonProps = ReactPropsFromRemoteComponentType<typeof Button>; // {onPress?(): void; children: ReactNode}
   ```
+
+It also exports a hook you can use to get direct, up-to-date access to a `StatefulRemoteSubscribable` created by `@remote-ui/async-subscription`:
+
+```tsx
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+import {useRemoteSubscription} from '@remote-ui/react';
+
+function MyComponent({
+  products,
+}: {
+  products: StatefulRemoteSubscribable<{id: string}[]>;
+}) {
+  const currentProducts = useRemoteSubscription(products);
+
+  return <>{currentProducts.map((product) => product.id)}</>;
+}
+```

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^16.13.1"
   },
   "dependencies": {
+    "@remote-ui/async-subscription": "^1.0.17",
     "@remote-ui/core": "^1.6.5",
     "@remote-ui/rpc": "^1.0.17",
     "@remote-ui/web-workers": "^1.3.2",

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export {useRemoteSubscription} from './subscription';

--- a/packages/react/src/hooks/subscription.ts
+++ b/packages/react/src/hooks/subscription.ts
@@ -1,0 +1,47 @@
+import {useState, useEffect, useDebugValue} from 'react';
+import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
+
+export function useRemoteSubscription<T>(
+  subscribable: StatefulRemoteSubscribable<T>,
+) {
+  const [state, setState] = useState(() => ({
+    subscribable,
+    value: subscribable.current,
+  }));
+
+  let valueToReturn = state.value;
+
+  if (state.subscribable !== subscribable) {
+    valueToReturn = subscribable.current;
+    setState({subscribable, value: valueToReturn});
+  }
+
+  useDebugValue(valueToReturn);
+
+  useEffect(() => {
+    const unsubscribe = subscribable.subscribe(checkForUpdates);
+
+    checkForUpdates();
+
+    return () => {
+      unsubscribe();
+    };
+
+    function checkForUpdates() {
+      const value = subscribable.current;
+
+      setState((previousState) => {
+        if (
+          previousState.subscribable !== subscribable ||
+          previousState.value === value
+        ) {
+          return previousState;
+        }
+
+        return {...previousState, value};
+      });
+    }
+  }, [subscribable]);
+
+  return valueToReturn;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,6 +3,7 @@ export {createRemoteRoot, RemoteReceiver} from '@remote-ui/core';
 export type {RemoteRoot} from '@remote-ui/core';
 export {render} from './render';
 export {createRemoteReactComponent} from './components';
+export {useRemoteSubscription} from './hooks';
 export type {
   ReactPropsFromRemoteComponentType,
   ReactComponentTypeFromRemoteComponentType,

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -6,5 +6,9 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "references": [{"path": "../core"}, {"path": "../web-workers"}]
+  "references": [
+    {"path": "../core"},
+    {"path": "../async-subscription"},
+    {"path": "../web-workers"}
+  ]
 }


### PR DESCRIPTION
This completely revamps to async subscriptions with new, clearer type and function names. It also divorces that library from `use-subscription`, and adds a dedicated `useRemoteSubscription` hook to `@remote-ui/react` and `@remote-ui/mini-react/compat` instead (that package is a bad dependency to have because there is no ESM version of it :/)