### PR TITLE
Fix receiver state not updating on mount

### DIFF
--- a/packages/core/src/receiver.ts
+++ b/packages/core/src/receiver.ts
@@ -95,7 +95,7 @@ export function createRemoteReceiver(): RemoteReceiver {
   >();
 
   let timeout: Promise<void> | null = null;
-  const state: RemoteReceiver['state'] = 'unmounted';
+  let state: RemoteReceiver['state'] = 'unmounted';
 
   const root: RemoteReceiverAttachableRoot = {
     id: ROOT_ID,
@@ -116,6 +116,8 @@ export function createRemoteReceiver(): RemoteReceiver {
 
       root.version += 1;
       root.children = normalizedChildren;
+
+      state = 'mounted';
 
       for (const child of normalizedChildren) {
         retain(child);

--- a/packages/core/src/tests/receiver.test.ts
+++ b/packages/core/src/tests/receiver.test.ts
@@ -1,0 +1,17 @@
+import {createRemoteReceiver} from '../receiver';
+import {ACTION_MOUNT} from '../types';
+
+describe('createRemoteReceiver()', () => {
+  describe('state', () => {
+    it('is `unmounted` while the mount() message has not been received', () => {
+      const receiver = createRemoteReceiver();
+      expect(receiver).toHaveProperty('state', 'unmounted');
+    });
+
+    it('is `mounted` once the mount() message has been received', () => {
+      const receiver = createRemoteReceiver();
+      receiver.receive(ACTION_MOUNT, []);
+      expect(receiver).toHaveProperty('state', 'mounted');
+    });
+  });
+});


### PR DESCRIPTION
`RemoteReceiver#state` was always returning `unmounted`, even after receiving the `mount` method. This PR updates it to return `mounted` when appropriate.