### PR TITLE
fix: simplify the stateful subscribable logic

### DIFF
--- a/packages/async-subscription/src/index.ts
+++ b/packages/async-subscription/src/index.ts
@@ -1,6 +1,7 @@
 export {makeStatefulSubscribable} from './stateful';
 export {createRemoteSubscribable} from './create';
 export type {
+  Subscriber,
   SyncSubscribable,
   RemoteSubscribable,
   StatefulRemoteSubscribable,


### PR DESCRIPTION
Related: https://github.com/Shopify/checkout-web/pull/4868

Co-authored-by: Henry Tao <henry.tao@shopify.com>

Each unsubscribe will clean up their own logic instead of calling a unified destroy method, which users might forget.