### PR TITLE
Add the ability for consumers to render custom components

### DIFF
--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -1,4 +1,4 @@
-import {memo, useMemo} from 'react';
+import {memo, useMemo, Fragment} from 'react';
 import {
   KIND_COMPONENT,
   KIND_TEXT,
@@ -87,18 +87,24 @@ function renderChildren(
   return [...children].map((child) => {
     switch (child.kind) {
       case KIND_COMPONENT:
-        return renderComponent({
-          component: child,
-          receiver,
-          controller,
-          key: child.id,
-        });
+        return (
+          <Fragment key={child.id}>
+            {renderComponent({
+              component: child,
+              receiver,
+              controller,
+            })}
+          </Fragment>
+        );
       case KIND_TEXT:
-        return renderText({
-          text: child,
-          receiver,
-          key: child.id,
-        });
+        return (
+          <Fragment key={child.id}>
+            {renderText({
+              text: child,
+              receiver,
+            })}
+          </Fragment>
+        );
       default:
         return null;
     }

--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -1,4 +1,4 @@
-import {memo, useMemo, Fragment} from 'react';
+import {memo, useMemo} from 'react';
 import {
   KIND_COMPONENT,
   KIND_TEXT,
@@ -22,12 +22,14 @@ export function renderComponent({
   component,
   controller,
   receiver,
+  key,
 }: RemoteComponentProps) {
   return (
     <RemoteComponent
       receiver={receiver}
       component={component}
       controller={controller}
+      key={key}
     />
   );
 }
@@ -87,24 +89,18 @@ function renderChildren(
   return [...children].map((child) => {
     switch (child.kind) {
       case KIND_COMPONENT:
-        return (
-          <Fragment key={child.id}>
-            {renderComponent({
-              component: child,
-              receiver,
-              controller,
-            })}
-          </Fragment>
-        );
+        return renderComponent({
+          component: child,
+          receiver,
+          controller,
+          key: child.id,
+        });
       case KIND_TEXT:
-        return (
-          <Fragment key={child.id}>
-            {renderText({
-              text: child,
-              receiver,
-            })}
-          </Fragment>
-        );
+        return renderText({
+          text: child,
+          receiver,
+          key: child.id,
+        });
       default:
         return null;
     }

--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -34,7 +34,8 @@ interface Props {
 const emptyObject = {};
 
 export const RemoteComponent = memo(
-  ({receiver, component, controller}: Props) => {
+  ({receiver, component, controller}: RemoteComponentProps) => {
+    const {renderComponent, renderText} = useRemoteRenderer();
     const Implementation = controller.get(component.type)!;
 
     const attached = useAttached(receiver, component);
@@ -65,7 +66,29 @@ export const RemoteComponent = memo(
 
     return (
       <Implementation {...props}>
+<<<<<<< HEAD
         {renderChildren(children, receiver, controller)}
+=======
+        {[...children].map((child) => {
+          let element: ReactElement | null;
+          switch (child.kind) {
+            case KIND_COMPONENT:
+              element = renderComponent({
+                component: child,
+                receiver,
+                controller,
+              });
+              break;
+            case KIND_TEXT:
+              element = renderText({text: child, receiver});
+              break;
+            default:
+              element = null;
+              break;
+          }
+          return element ? cloneElement(element, {key: child.id}) : null;
+        })}
+>>>>>>> a2eb711 (Add the ability for consumers to render custom components)
       </Implementation>
     );
   },

--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -6,18 +6,15 @@ import {
 } from '@remote-ui/core';
 import type {
   RemoteReceiver,
-  RemoteReceiverAttachableFragment,
   RemoteReceiverAttachableChild,
 } from '@remote-ui/core';
 
 import {useAttached} from './hooks';
-import type {Controller, RemoteComponentProps} from './types';
-
-interface RemoteFragmentProps {
-  receiver: RemoteReceiver;
-  fragment: RemoteReceiverAttachableFragment;
-  controller: Controller;
-}
+import type {
+  Controller,
+  RemoteComponentProps,
+  RemoteFragmentProps,
+} from './types';
 
 const emptyObject = {};
 
@@ -94,13 +91,13 @@ function renderChildren(
           component: child,
           receiver,
           controller,
-          ...({key: child.id} as any),
+          key: child.id,
         });
       case KIND_TEXT:
         return renderText({
           text: child,
           receiver,
-          ...({key: child.id} as any),
+          key: child.id,
         });
       default:
         return null;

--- a/packages/react/src/host/RemoteRenderer.tsx
+++ b/packages/react/src/host/RemoteRenderer.tsx
@@ -1,41 +1,55 @@
-import {memo} from 'react';
+import {cloneElement, memo, ReactElement, useMemo} from 'react';
 import {KIND_COMPONENT, KIND_TEXT, RemoteReceiver} from '@remote-ui/core';
 
 import type {Controller} from './controller';
 import {useAttached} from './hooks';
-import {RemoteText} from './RemoteText';
-import {RemoteComponent} from './RemoteComponent';
+import {renderText as defaultRenderText} from './RemoteText';
+import {renderComponent as defaultRenderComponent} from './RemoteComponent';
+import {RemoteRendererContext} from './context';
+import type {RemoteComponentProps, RemoteTextProps} from './types';
 
-interface Props {
+export interface RemoteRendererProps {
   receiver: RemoteReceiver;
   controller: Controller;
+  renderComponent?: (props: RemoteComponentProps) => ReactElement;
+  renderText?: (props: RemoteTextProps) => ReactElement;
 }
 
-export const RemoteRenderer = memo(({controller, receiver}: Props) => {
-  const {children} = useAttached(receiver, receiver.attached.root)!;
+export const RemoteRenderer = memo(
+  ({
+    controller,
+    receiver,
+    renderComponent = defaultRenderComponent,
+    renderText = defaultRenderText,
+  }: RemoteRendererProps) => {
+    const {children} = useAttached(receiver, receiver.attached.root)!;
+    const renderContextValue = useMemo(() => ({renderText, renderComponent}), [
+      renderText,
+      renderComponent,
+    ]);
 
-  return (
-    <>
-      {children.map((child) => {
-        switch (child.kind) {
-          case KIND_COMPONENT:
-            return (
-              <RemoteComponent
-                key={child.id}
-                component={child}
-                receiver={receiver}
-                controller={controller}
-                __type__={(controller.get(child.type) as any)?.__type__}
-              />
-            );
-          case KIND_TEXT:
-            return (
-              <RemoteText key={child.id} text={child} receiver={receiver} />
-            );
-          default:
-            return null;
-        }
-      })}
-    </>
-  );
-});
+    return (
+      <RemoteRendererContext.Provider value={renderContextValue}>
+        {children.map((child) => {
+          let element: ReactElement | null;
+          switch (child.kind) {
+            case KIND_COMPONENT:
+              element = renderComponent({
+                component: child,
+                receiver,
+                controller,
+              });
+              break;
+            case KIND_TEXT:
+              element = renderText({text: child, receiver});
+              break;
+            default:
+              element = null;
+              break;
+          }
+          return element ? cloneElement(element, {key: child.id}) : null;
+        })}
+      </RemoteRendererContext.Provider>
+    );
+  },
+);

--- a/packages/react/src/host/RemoteRenderer.tsx
+++ b/packages/react/src/host/RemoteRenderer.tsx
@@ -1,55 +1,41 @@
-import {cloneElement, memo, ReactElement, useMemo} from 'react';
+import {memo} from 'react';
 import {KIND_COMPONENT, KIND_TEXT, RemoteReceiver} from '@remote-ui/core';
 
-import type {Controller} from './controller';
+import type {Controller} from './types';
 import {useAttached} from './hooks';
-import {renderText as defaultRenderText} from './RemoteText';
-import {renderComponent as defaultRenderComponent} from './RemoteComponent';
-import {RemoteRendererContext} from './context';
-import type {RemoteComponentProps, RemoteTextProps} from './types';
 
 export interface RemoteRendererProps {
   receiver: RemoteReceiver;
   controller: Controller;
-  renderComponent?: (props: RemoteComponentProps) => ReactElement;
-  renderText?: (props: RemoteTextProps) => ReactElement;
 }
 
 export const RemoteRenderer = memo(
-  ({
-    controller,
-    receiver,
-    renderComponent = defaultRenderComponent,
-    renderText = defaultRenderText,
-  }: RemoteRendererProps) => {
+  ({controller, receiver}: RemoteRendererProps) => {
     const {children} = useAttached(receiver, receiver.attached.root)!;
-    const renderContextValue = useMemo(() => ({renderText, renderComponent}), [
-      renderText,
-      renderComponent,
-    ]);
+    const {renderComponent, renderText} = controller.renderer;
 
     return (
-      <RemoteRendererContext.Provider value={renderContextValue}>
+      <>
         {children.map((child) => {
-          let element: ReactElement | null;
           switch (child.kind) {
             case KIND_COMPONENT:
-              element = renderComponent({
+              return renderComponent({
                 component: child,
                 receiver,
                 controller,
+                ...({key: child.id} as any),
               });
-              break;
             case KIND_TEXT:
-              element = renderText({text: child, receiver});
-              break;
+              return renderText({
+                text: child,
+                receiver,
+                ...({key: child.id} as any),
+              });
             default:
-              element = null;
-              break;
+              return null;
           }
-          return element ? cloneElement(element, {key: child.id}) : null;
         })}
-      </RemoteRendererContext.Provider>
+      </>
     );
   },
 );

--- a/packages/react/src/host/RemoteRenderer.tsx
+++ b/packages/react/src/host/RemoteRenderer.tsx
@@ -23,13 +23,13 @@ export const RemoteRenderer = memo(
                 component: child,
                 receiver,
                 controller,
-                ...({key: child.id} as any),
+                key: child.id,
               });
             case KIND_TEXT:
               return renderText({
                 text: child,
                 receiver,
-                ...({key: child.id} as any),
+                key: child.id,
               });
             default:
               return null;

--- a/packages/react/src/host/RemoteRenderer.tsx
+++ b/packages/react/src/host/RemoteRenderer.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {Fragment, memo} from 'react';
 import {KIND_COMPONENT, KIND_TEXT, RemoteReceiver} from '@remote-ui/core';
 
 import type {Controller} from './types';
@@ -19,18 +19,24 @@ export const RemoteRenderer = memo(
         {children.map((child) => {
           switch (child.kind) {
             case KIND_COMPONENT:
-              return renderComponent({
-                component: child,
-                receiver,
-                controller,
-                key: child.id,
-              });
+              return (
+                <Fragment key={child.id}>
+                  {renderComponent({
+                    component: child,
+                    receiver,
+                    controller,
+                  })}
+                </Fragment>
+              );
             case KIND_TEXT:
-              return renderText({
-                text: child,
-                receiver,
-                key: child.id,
-              });
+              return (
+                <Fragment key={child.id}>
+                  {renderText({
+                    text: child,
+                    receiver,
+                  })}
+                </Fragment>
+              );
             default:
               return null;
           }

--- a/packages/react/src/host/RemoteRenderer.tsx
+++ b/packages/react/src/host/RemoteRenderer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, memo} from 'react';
+import {memo} from 'react';
 import {KIND_COMPONENT, KIND_TEXT, RemoteReceiver} from '@remote-ui/core';
 
 import type {Controller} from './types';
@@ -19,24 +19,18 @@ export const RemoteRenderer = memo(
         {children.map((child) => {
           switch (child.kind) {
             case KIND_COMPONENT:
-              return (
-                <Fragment key={child.id}>
-                  {renderComponent({
-                    component: child,
-                    receiver,
-                    controller,
-                  })}
-                </Fragment>
-              );
+              return renderComponent({
+                component: child,
+                receiver,
+                controller,
+                key: child.id,
+              });
             case KIND_TEXT:
-              return (
-                <Fragment key={child.id}>
-                  {renderText({
-                    text: child,
-                    receiver,
-                  })}
-                </Fragment>
-              );
+              return renderText({
+                text: child,
+                receiver,
+                key: child.id,
+              });
             default:
               return null;
           }

--- a/packages/react/src/host/RemoteText.tsx
+++ b/packages/react/src/host/RemoteText.tsx
@@ -1,17 +1,14 @@
 import {memo} from 'react';
-import type {
-  RemoteReceiver,
-  RemoteReceiverAttachableText,
-} from '@remote-ui/core';
 
+import type {RemoteTextProps} from './types';
 import {useAttached} from './hooks';
 
-interface Props {
-  text: RemoteReceiverAttachableText;
-  receiver: RemoteReceiver;
+
+export function renderText({text, receiver}: RemoteTextProps) {
+  return <RemoteText text={text} receiver={receiver} />;
 }
 
-export const RemoteText = memo(({text, receiver}: Props) => {
+export const RemoteText = memo(({text, receiver}: RemoteTextProps) => {
   const attached = useAttached(receiver, text);
   return attached ? <>{attached.text}</> : null;
 });

--- a/packages/react/src/host/RemoteText.tsx
+++ b/packages/react/src/host/RemoteText.tsx
@@ -3,9 +3,8 @@ import {memo} from 'react';
 import type {RemoteTextProps} from './types';
 import {useAttached} from './hooks';
 
-
-export function renderText({text, receiver}: RemoteTextProps) {
-  return <RemoteText text={text} receiver={receiver} />;
+export function renderText({text, receiver, ...extraProps}: RemoteTextProps) {
+  return <RemoteText {...extraProps} text={text} receiver={receiver} />;
 }
 
 export const RemoteText = memo(({text, receiver}: RemoteTextProps) => {

--- a/packages/react/src/host/RemoteText.tsx
+++ b/packages/react/src/host/RemoteText.tsx
@@ -3,8 +3,8 @@ import {memo} from 'react';
 import type {RemoteTextProps} from './types';
 import {useAttached} from './hooks';
 
-export function renderText({text, receiver, ...extraProps}: RemoteTextProps) {
-  return <RemoteText {...extraProps} text={text} receiver={receiver} />;
+export function renderText({text, receiver, key}: RemoteTextProps) {
+  return <RemoteText key={key} text={text} receiver={receiver} />;
 }
 
 export const RemoteText = memo(({text, receiver}: RemoteTextProps) => {

--- a/packages/react/src/host/context.ts
+++ b/packages/react/src/host/context.ts
@@ -1,19 +1,9 @@
-import {createContext, ReactElement} from 'react';
-import type {RemoteComponentProps, RemoteTextProps} from './types';
+import {createContext} from 'react';
 
 export const ControllerContext = createContext<
-  import('./controller').Controller | null
+  import('./types').Controller | null
 >(null);
 
 export const RemoteReceiverContext = createContext<
   import('@remote-ui/core').RemoteReceiver | null
 >(null);
-
-export interface RemoteRendererContextProps {
-  renderComponent: (props: RemoteComponentProps) => ReactElement;
-  renderText: (props: RemoteTextProps) => ReactElement;
-}
-
-export const RemoteRendererContext = createContext<RemoteRendererContextProps | null>(
-  null,
-);

--- a/packages/react/src/host/context.ts
+++ b/packages/react/src/host/context.ts
@@ -1,4 +1,5 @@
-import {createContext} from 'react';
+import {createContext, ReactElement} from 'react';
+import type {RemoteComponentProps, RemoteTextProps} from './types';
 
 export const ControllerContext = createContext<
   import('./controller').Controller | null
@@ -7,3 +8,12 @@ export const ControllerContext = createContext<
 export const RemoteReceiverContext = createContext<
   import('@remote-ui/core').RemoteReceiver | null
 >(null);
+
+export interface RemoteRendererContextProps {
+  renderComponent: (props: RemoteComponentProps) => ReactElement;
+  renderText: (props: RemoteTextProps) => ReactElement;
+}
+
+export const RemoteRendererContext = createContext<RemoteRendererContextProps | null>(
+  null,
+);

--- a/packages/react/src/host/controller.tsx
+++ b/packages/react/src/host/controller.tsx
@@ -1,15 +1,17 @@
 import type {ComponentType} from 'react';
-import type {RemoteComponentType} from '@remote-ui/core';
+import type {Controller, Renderer} from './types';
+
+import {renderComponent} from './RemoteComponent';
+import {renderText} from './RemoteText';
 
 export interface ComponentMapping {
   [key: string]: ComponentType<any>;
 }
 
-export interface Controller {
-  get(type: string | RemoteComponentType<string, any, any>): ComponentType<any>;
-}
-
-export function createController(components: ComponentMapping): Controller {
+export function createController(
+  components: ComponentMapping,
+  renderer: Partial<Renderer> = {},
+): Controller {
   const registry = new Map(Object.entries(components));
 
   return {
@@ -19,6 +21,11 @@ export function createController(components: ComponentMapping): Controller {
         throw new Error(`Unknown component: ${type}`);
       }
       return value;
+    },
+    renderer: {
+      renderComponent,
+      renderText,
+      ...renderer,
     },
   };
 }

--- a/packages/react/src/host/controller.tsx
+++ b/packages/react/src/host/controller.tsx
@@ -1,16 +1,25 @@
 import type {ComponentType} from 'react';
 import type {Controller, Renderer} from './types';
 
-import {renderComponent} from './RemoteComponent';
-import {renderText} from './RemoteText';
+import {renderComponent as defaultRenderComponent} from './RemoteComponent';
+import {renderText as defaultRenderText} from './RemoteText';
 
 export interface ComponentMapping {
   [key: string]: ComponentType<any>;
 }
 
+interface RendererFactory {
+  componentRenderer: (
+    defaultRenderer: Renderer['renderComponent'],
+  ) => Renderer['renderComponent'];
+  textRenderer: (
+    defaultRenderer: Renderer['renderText'],
+  ) => Renderer['renderText'];
+}
+
 export function createController(
   components: ComponentMapping,
-  renderer: Partial<Renderer> = {},
+  {componentRenderer, textRenderer}: Partial<RendererFactory> = {},
 ): Controller {
   const registry = new Map(Object.entries(components));
 
@@ -23,9 +32,9 @@ export function createController(
       return value;
     },
     renderer: {
-      renderComponent,
-      renderText,
-      ...renderer,
+      renderComponent:
+        componentRenderer?.(defaultRenderComponent) ?? defaultRenderComponent,
+      renderText: textRenderer?.(defaultRenderText) ?? defaultRenderText,
     },
   };
 }

--- a/packages/react/src/host/controller.tsx
+++ b/packages/react/src/host/controller.tsx
@@ -23,9 +23,6 @@ interface RendererFactory {
   renderText(props: RemoteTextProps, options: RenderTextOptions): ReactNode;
 }
 
-const renderComponentOptions = {renderDefault: defaultRenderComponent};
-const renderTextOptions = {renderDefault: defaultRenderText};
-
 export function createController(
   components: ComponentMapping,
   {
@@ -35,10 +32,20 @@ export function createController(
 ): Controller {
   const registry = new Map(Object.entries(components));
   const renderComponent: Renderer['renderComponent'] = externalRenderComponent
-    ? (component) => externalRenderComponent(component, renderComponentOptions)
+    ? (componentProps) =>
+        externalRenderComponent(componentProps, {
+          renderDefault() {
+            return defaultRenderComponent(componentProps);
+          },
+        })
     : defaultRenderComponent;
   const renderText: Renderer['renderText'] = externalRenderText
-    ? (text) => externalRenderText(text, renderTextOptions)
+    ? (textProps) =>
+        externalRenderText(textProps, {
+          renderDefault() {
+            return defaultRenderText(textProps);
+          },
+        })
     : defaultRenderText;
 
   return {

--- a/packages/react/src/host/controller.tsx
+++ b/packages/react/src/host/controller.tsx
@@ -1,4 +1,4 @@
-import type {ComponentType, ReactElement} from 'react';
+import type {ComponentType, ReactNode} from 'react';
 import type {
   Controller,
   RemoteComponentProps,
@@ -19,8 +19,8 @@ interface RendererFactory {
   renderComponent(
     props: RemoteComponentProps,
     options: RenderComponentOptions,
-  ): ReactElement;
-  renderText(props: RemoteTextProps, options: RenderTextOptions): ReactElement;
+  ): ReactNode;
+  renderText(props: RemoteTextProps, options: RenderTextOptions): ReactNode;
 }
 
 const renderComponentOptions = {renderDefault: defaultRenderComponent};
@@ -38,7 +38,7 @@ export function createController(
     ? (component) => externalRenderComponent(component, renderComponentOptions)
     : defaultRenderComponent;
   const renderText: Renderer['renderText'] = externalRenderText
-    ? (component) => externalRenderText(component, renderTextOptions)
+    ? (text) => externalRenderText(text, renderTextOptions)
     : defaultRenderText;
 
   return {

--- a/packages/react/src/host/hooks.ts
+++ b/packages/react/src/host/hooks.ts
@@ -1,7 +1,7 @@
 import {useState, useDebugValue, useContext, useEffect} from 'react';
 import type {RemoteReceiver, RemoteReceiverAttachable} from '@remote-ui/core';
 
-import {ControllerContext, RemoteReceiverContext, RemoteRendererContext} from './context';
+import {ControllerContext, RemoteReceiverContext} from './context';
 
 export function useController() {
   const controller = useContext(ControllerContext);
@@ -21,16 +21,6 @@ export function useRemoteReceiver() {
   }
 
   return receiver;
-}
-
-export function useRemoteRenderer() {
-  const renderer = useContext(RemoteRendererContext);
-
-  if (renderer == null) {
-    throw new Error('No remote-ui Renderer instance found in context');
-  }
-
-  return renderer;
 }
 
 interface State<T extends RemoteReceiverAttachable> {

--- a/packages/react/src/host/hooks.ts
+++ b/packages/react/src/host/hooks.ts
@@ -1,7 +1,7 @@
 import {useState, useDebugValue, useContext, useEffect} from 'react';
 import type {RemoteReceiver, RemoteReceiverAttachable} from '@remote-ui/core';
 
-import {ControllerContext, RemoteReceiverContext} from './context';
+import {ControllerContext, RemoteReceiverContext, RemoteRendererContext} from './context';
 
 export function useController() {
   const controller = useContext(ControllerContext);
@@ -21,6 +21,16 @@ export function useRemoteReceiver() {
   }
 
   return receiver;
+}
+
+export function useRemoteRenderer() {
+  const renderer = useContext(RemoteRendererContext);
+
+  if (renderer == null) {
+    throw new Error('No remote-ui Renderer instance found in context');
+  }
+
+  return renderer;
 }
 
 interface State<T extends RemoteReceiverAttachable> {

--- a/packages/react/src/host/index.ts
+++ b/packages/react/src/host/index.ts
@@ -6,7 +6,7 @@ export type {RemoteRendererProps} from './RemoteRenderer';
 export {RemoteComponent} from './RemoteComponent';
 export {RemoteText} from './RemoteText';
 export {createController} from './controller';
-export type {Controller, ComponentMapping} from './controller';
+export type {ComponentMapping} from './controller';
 export type {
   ReactPropsFromRemoteComponentType,
   ReactComponentTypeFromRemoteComponentType,
@@ -14,4 +14,4 @@ export type {
 export {RemoteReceiverContext, ControllerContext} from './context';
 export {useRemoteReceiver, useAttached} from './hooks';
 export {useWorker} from './workers';
-export type {RemoteComponentProps, RemoteTextProps} from './types';
+export type {Controller, RemoteComponentProps, RemoteTextProps} from './types';

--- a/packages/react/src/host/index.ts
+++ b/packages/react/src/host/index.ts
@@ -2,6 +2,9 @@ export type {RemoteReceiver} from '@remote-ui/core';
 export {createRemoteReceiver} from '@remote-ui/core';
 
 export {RemoteRenderer} from './RemoteRenderer';
+export type {RemoteRendererProps} from './RemoteRenderer';
+export {RemoteComponent} from './RemoteComponent';
+export {RemoteText} from './RemoteText';
 export {createController} from './controller';
 export type {Controller, ComponentMapping} from './controller';
 export type {
@@ -9,5 +12,6 @@ export type {
   ReactComponentTypeFromRemoteComponentType,
 } from '../types';
 export {RemoteReceiverContext, ControllerContext} from './context';
-export {useRemoteReceiver} from './hooks';
+export {useRemoteReceiver, useAttached} from './hooks';
 export {useWorker} from './workers';
+export type {RemoteComponentProps, RemoteTextProps} from './types';

--- a/packages/react/src/host/types.ts
+++ b/packages/react/src/host/types.ts
@@ -32,6 +32,14 @@ export interface Controller {
 }
 
 export interface Renderer {
-  renderComponent: (props: RemoteComponentProps) => ReactElement;
-  renderText: (props: RemoteTextProps) => ReactElement;
+  renderComponent(props: RemoteComponentProps): ReactElement;
+  renderText(props: RemoteTextProps): ReactElement;
+}
+
+export interface RenderComponentOptions {
+  renderDefault: Renderer['renderComponent'];
+}
+
+export interface RenderTextOptions {
+  renderDefault: Renderer['renderText'];
 }

--- a/packages/react/src/host/types.ts
+++ b/packages/react/src/host/types.ts
@@ -4,16 +4,25 @@ import type {
   RemoteReceiverAttachableComponent,
   RemoteReceiverAttachableText,
   RemoteComponentType,
+  RemoteReceiverAttachableFragment,
 } from '@remote-ui/core';
 
 export interface RemoteTextProps {
   text: RemoteReceiverAttachableText;
   receiver: RemoteReceiver;
+  key?: string | number;
 }
 
 export interface RemoteComponentProps {
   receiver: RemoteReceiver;
   component: RemoteReceiverAttachableComponent;
+  controller: Controller;
+  key?: string | number;
+}
+
+export interface RemoteFragmentProps {
+  receiver: RemoteReceiver;
+  fragment: RemoteReceiverAttachableFragment;
   controller: Controller;
 }
 

--- a/packages/react/src/host/types.ts
+++ b/packages/react/src/host/types.ts
@@ -10,14 +10,14 @@ import type {
 export interface RemoteTextProps {
   text: RemoteReceiverAttachableText;
   receiver: RemoteReceiver;
-  key?: string | number;
+  key: string | number;
 }
 
 export interface RemoteComponentProps {
   receiver: RemoteReceiver;
   component: RemoteReceiverAttachableComponent;
   controller: Controller;
-  key?: string | number;
+  key: string | number;
 }
 
 export interface RemoteFragmentProps {

--- a/packages/react/src/host/types.ts
+++ b/packages/react/src/host/types.ts
@@ -1,10 +1,10 @@
+import type {ComponentType, ReactElement} from 'react';
 import type {
   RemoteReceiver,
   RemoteReceiverAttachableComponent,
   RemoteReceiverAttachableText,
+  RemoteComponentType,
 } from '@remote-ui/core';
-
-import type {Controller} from './controller';
 
 export interface RemoteTextProps {
   text: RemoteReceiverAttachableText;
@@ -15,4 +15,14 @@ export interface RemoteComponentProps {
   receiver: RemoteReceiver;
   component: RemoteReceiverAttachableComponent;
   controller: Controller;
+}
+
+export interface Controller {
+  get(type: string | RemoteComponentType<string, any, any>): ComponentType<any>;
+  renderer: Renderer;
+}
+
+export interface Renderer {
+  renderComponent: (props: RemoteComponentProps) => ReactElement;
+  renderText: (props: RemoteTextProps) => ReactElement;
 }

--- a/packages/react/src/host/types.ts
+++ b/packages/react/src/host/types.ts
@@ -1,0 +1,18 @@
+import type {
+  RemoteReceiver,
+  RemoteReceiverAttachableComponent,
+  RemoteReceiverAttachableText,
+} from '@remote-ui/core';
+
+import type {Controller} from './controller';
+
+export interface RemoteTextProps {
+  text: RemoteReceiverAttachableText;
+  receiver: RemoteReceiver;
+}
+
+export interface RemoteComponentProps {
+  receiver: RemoteReceiver;
+  component: RemoteReceiverAttachableComponent;
+  controller: Controller;
+}

--- a/packages/react/src/host/types.ts
+++ b/packages/react/src/host/types.ts
@@ -1,4 +1,4 @@
-import type {ComponentType, ReactElement} from 'react';
+import type {ComponentType, ReactNode} from 'react';
 import type {
   RemoteReceiver,
   RemoteReceiverAttachableComponent,
@@ -32,8 +32,8 @@ export interface Controller {
 }
 
 export interface Renderer {
-  renderComponent(props: RemoteComponentProps): ReactElement;
-  renderText(props: RemoteTextProps): ReactElement;
+  renderComponent(props: RemoteComponentProps): ReactNode;
+  renderText(props: RemoteTextProps): ReactNode;
 }
 
 export interface RenderComponentOptions {

--- a/packages/react/src/host/types.ts
+++ b/packages/react/src/host/types.ts
@@ -37,9 +37,9 @@ export interface Renderer {
 }
 
 export interface RenderComponentOptions {
-  renderDefault: Renderer['renderComponent'];
+  renderDefault(): ReactNode;
 }
 
 export interface RenderTextOptions {
-  renderDefault: Renderer['renderText'];
+  renderDefault(): ReactNode;
 }


### PR DESCRIPTION
Allow consumers of `RemoteRenderer` to pass in their own custom component renderer or text renderer. 

This will allow React Native to override the default behaviour of text rendering, since React Native requires that all Text objects to be wrapped in a ReactElement. 

For web, we can remove the hack that gets the `__type__` out of the component and move it back to web's side by overriding the component rendering.