### PR TITLE
Adds iframe-related adaptors

### DIFF
--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -323,3 +323,50 @@ This excludes many types, but of particular note are the following restrictions:
 - No `ArrayBuffer` or typed arrays
 - No `URL` or `RegExp`
 - Instances of classes will transfer, but only their own properties — that is, properties on their prototype chain **will not** be transferred (additionally, no effort is made to preserve `instanceof` or similar checks on the transferred value)
+
+## Adaptors
+
+This library also provides a collection of adaptors that transform common `postMessage`-related objects into an `Endpoint`. You can of course write your own adaptor for these (and may need to, if you have complex needs), but these adaptors can be a helpful starting point:
+
+- `fromWebWorker()` allows you to create an `Endpoint` from a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers):
+
+  ```ts
+  import {fromWebWorker} from '@remote-ui/rpc';
+
+  const worker = new Worker('./worker.js', import.meta.url);
+  const endpoint = fromWebWorker(worker);
+  ```
+
+- `fromMessagePort()` allows you to create an `Endpoint` from a [`MessagePort` object](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort)
+
+  ```ts
+  import {fromMessagePort} from '@remote-ui/rpc';
+
+  const channel = new MessageChannel();
+  const endpoint = fromWebWorker(channel.port2);
+  ```
+
+- `fromIframe()` allows you to create an `Endpoint` from a browser window by connecting it to a child `iframe`:
+
+  ```ts
+  import {fromIframe} from '@remote-ui/rpc';
+
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('src', '/my-iframe-page');
+  document.appendChild(iframe);
+
+  const endpoint = fromIframe(iframe);
+
+  // Optionally, you can pass {terminate: false} to prevent the iframe from being
+  // removed from the DOM when the endpoint is terminated:
+  const endpoint2 = fromIframe(iframe, {terminate: false});
+  ```
+
+- `fromInsideIframe()` allows you to create an `Endpoint` from a parent browser window, from _within_ a child `iframe`:
+
+  ```ts
+  // Can only be run from inside an iframe, where `self.parent` is available
+  import {fromInsideIframe} from '@remote-ui/rpc';
+
+  const endpoint = fromInsideIframe();
+  ```

--- a/packages/rpc/src/adaptors/iframe-child.ts
+++ b/packages/rpc/src/adaptors/iframe-child.ts
@@ -1,0 +1,41 @@
+import type {MessageEndpoint} from '../types';
+
+export function fromInsideIframe(): MessageEndpoint {
+  if (typeof self === 'undefined' || self.parent == null) {
+    throw new Error(
+      `This does not appear to be a child iframe, because there is no parent window.`,
+    );
+  }
+
+  const {parent} = self;
+
+  // We need to store the listener, because we wrap it to do some origin checking. Ideally,
+  // we’d instead store an `AbortController`, and use its signal to cancel the listeners,
+  // but that isn’t widely supported.
+  const listenerMap = new WeakMap<
+    (event: MessageEvent) => void,
+    (event: MessageEvent) => void
+  >();
+
+  return {
+    postMessage(message, transfer) {
+      parent.postMessage(message, parent.location.origin, transfer);
+    },
+    addEventListener(event, listener) {
+      const wrappedListener = (event: MessageEvent) => {
+        if (event.target !== parent) return;
+        listener(event);
+      };
+
+      listenerMap.set(listener, wrappedListener);
+      self.addEventListener(event, wrappedListener);
+    },
+    removeEventListener(event, listener) {
+      const wrappedListener = listenerMap.get(listener);
+      if (wrappedListener == null) return;
+
+      listenerMap.delete(listener);
+      self.removeEventListener(event, wrappedListener);
+    },
+  };
+}

--- a/packages/rpc/src/adaptors/iframe-parent.ts
+++ b/packages/rpc/src/adaptors/iframe-parent.ts
@@ -1,0 +1,62 @@
+import type {MessageEndpoint} from '../types';
+
+export function fromIframe(
+  target: HTMLIFrameElement,
+  {terminate: shouldTerminate = true} = {},
+): MessageEndpoint {
+  if (typeof window === 'undefined') {
+    throw new Error(
+      `You can only run fromIframe() in a browser context, but no window was found.`,
+    );
+  }
+
+  // We need to store the listener, because we wrap it to do some origin checking. Ideally,
+  // we’d instead store an `AbortController`, and use its signal to cancel the listeners,
+  // but that isn’t widely supported.
+  const listenerMap = new WeakMap<
+    (event: MessageEvent) => void,
+    (event: MessageEvent) => void
+  >();
+
+  const iframeLoadPromise =
+    target.contentDocument?.readyState === 'complete'
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          target.addEventListener('load', () => resolve(), {
+            once: true,
+          });
+        });
+
+  return {
+    async postMessage(message, transfer) {
+      if (target.contentDocument?.readyState !== 'complete') {
+        await iframeLoadPromise;
+      }
+
+      target.contentWindow!.postMessage(
+        message,
+        target.contentWindow!.location.origin,
+        transfer,
+      );
+    },
+    addEventListener(event, listener) {
+      const wrappedListener = (event: MessageEvent) => {
+        if (event.target !== target) return;
+        listener(event);
+      };
+
+      listenerMap.set(listener, wrappedListener);
+      self.addEventListener(event, wrappedListener);
+    },
+    removeEventListener(event, listener) {
+      const wrappedListener = listenerMap.get(listener);
+      if (wrappedListener == null) return;
+
+      listenerMap.delete(listener);
+      self.removeEventListener(event, wrappedListener);
+    },
+    terminate() {
+      if (shouldTerminate) target.remove();
+    },
+  };
+}

--- a/packages/rpc/src/adaptors/index.ts
+++ b/packages/rpc/src/adaptors/index.ts
@@ -1,2 +1,4 @@
+export {fromIframe} from './iframe-parent';
+export {fromInsideIframe} from './iframe-child';
 export {fromMessagePort} from './message-port';
 export {fromWebWorker} from './web-worker';

--- a/packages/rpc/src/adaptors/message-port.ts
+++ b/packages/rpc/src/adaptors/message-port.ts
@@ -1,4 +1,4 @@
-import {MessageEndpoint} from '../types';
+import type {MessageEndpoint} from '../types';
 
 export function fromMessagePort(messagePort: MessagePort): MessageEndpoint {
   return {

--- a/packages/rpc/src/adaptors/web-worker.ts
+++ b/packages/rpc/src/adaptors/web-worker.ts
@@ -1,4 +1,4 @@
-import {MessageEndpoint} from '../types';
+import type {MessageEndpoint} from '../types';
 
 export function fromWebWorker(worker: Worker): MessageEndpoint {
   return worker;

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -1,7 +1,12 @@
 export {createEndpoint} from './endpoint';
 export type {Endpoint, CreateEndpointOptions} from './endpoint';
 export {createBasicEncoder} from './encoding';
-export {fromMessagePort, fromWebWorker} from './adaptors';
+export {
+  fromMessagePort,
+  fromWebWorker,
+  fromIframe,
+  fromInsideIframe,
+} from './adaptors';
 export {
   retain,
   release,


### PR DESCRIPTION
This PR adds a few iframe-related adaptors to `@remote-ui/rpc`. I was working on a "web-native" demo — including no bundling — and for that purpose, workers were a bit annoying, because they do not widely support native ESM. Instead, I opted to use an iframe as the sandbox. That works great, but there is a bunch of annoying boilerplate for wrapping an iframe as an endpoint on both the parent and child. This PR abstracts that boilerplate into a couple of reusable adaptors.