### PR TITLE
Rethrow error

### DIFF
--- a/packages/rpc/src/endpoint.ts
+++ b/packages/rpc/src/endpoint.ts
@@ -186,6 +186,7 @@ export function createEndpoint<T>(
         } catch (error) {
           const {name, message, stack} = error;
           send(RESULT, [id, {name, message, stack}]);
+          throw error;
         } finally {
           stackFrame.release();
         }
@@ -229,6 +230,7 @@ export function createEndpoint<T>(
         } catch (error) {
           const {name, message, stack} = error;
           send(FUNCTION_RESULT, [callId, {name, message, stack}]);
+          throw error;
         }
 
         break;


### PR DESCRIPTION
This PR rethrows error after sending it to the host endpoint. This will help with analytics in WebWorker. See https://github.com/Shopify/checkout-web/issues/5252#issuecomment-863488300