### PR TITLE
Fix crossorigin iframe errors in RPC library

### DIFF
--- a/packages/rpc/src/adaptors/iframe-child.ts
+++ b/packages/rpc/src/adaptors/iframe-child.ts
@@ -1,6 +1,6 @@
 import type {MessageEndpoint} from '../types';
 
-export function fromInsideIframe(): MessageEndpoint {
+export function fromInsideIframe({targetOrigin = '*'} = {}): MessageEndpoint {
   if (typeof self === 'undefined' || self.parent == null) {
     throw new Error(
       `This does not appear to be a child iframe, because there is no parent window.`,
@@ -19,7 +19,7 @@ export function fromInsideIframe(): MessageEndpoint {
 
   return {
     postMessage(message, transfer) {
-      parent.postMessage(message, parent.location.origin, transfer);
+      parent.postMessage(message, targetOrigin, transfer);
     },
     addEventListener(event, listener) {
       const wrappedListener = (event: MessageEvent) => {

--- a/packages/rpc/src/adaptors/iframe-parent.ts
+++ b/packages/rpc/src/adaptors/iframe-parent.ts
@@ -2,7 +2,7 @@ import type {MessageEndpoint} from '../types';
 
 export function fromIframe(
   target: HTMLIFrameElement,
-  {terminate: shouldTerminate = true} = {},
+  {terminate: shouldTerminate = true, targetOrigin = '*'} = {},
 ): MessageEndpoint {
   if (typeof window === 'undefined') {
     throw new Error(
@@ -33,11 +33,7 @@ export function fromIframe(
         await iframeLoadPromise;
       }
 
-      target.contentWindow!.postMessage(
-        message,
-        target.contentWindow!.location.origin,
-        transfer,
-      );
+      target.contentWindow!.postMessage(message, targetOrigin, transfer);
     },
     addEventListener(event, listener) {
       const wrappedListener = (event: MessageEvent) => {


### PR DESCRIPTION
I added adaptors for turning iframe into RPC endpoints in https://github.com/Shopify/remote-ui/pull/97. In building that feature, I had only used same origin iframes. I'm trying to use these utilities in a context that has cross-origin iframes, and they throw errors as a result of trying to reach into the frame to access a global (`window.location` specifically, which was being used to set the target origin on the `postMessage`).

This PR fixes the issue by defaulting to using `*` as the target origin for iframe postmessages. It's technically better practice to specify an explicit origin (and I made that possible with optional `targetOrigin` options for both the parent and child iframe adaptors), but since these adaptors are already checking to make sure `event.target` for post messages is the expected window (parent for the child, child for the parent), I don't think it's a big deal to lose the default origin stuff I had before.