### PR TITLE
Deduplicate @types/react

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,16 +3094,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.4.tgz#a67c6f7a460d2660e950d9ccc1c2f18525c28220"
-  integrity sha512-onz2BqScSFMoTRdJUZUDD/7xrusM8hBA2Fktk2qgaTYPCgPvWnDEgkrOs8hhPUf2jfcIXkJ5yK6VfYormJS3Jw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=17.0.0 <18.0.0":
+"@types/react@*", "@types/react@>=17.0.0 <18.0.0":
   version "17.0.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
   integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==


### PR DESCRIPTION
Follow up of https://github.com/Shopify/remote-ui/pull/111/files#r674172103

## Context: 
`types/react` was moved from peerDependencies to dependencies since this PR https://github.com/Shopify/remote-ui/pull/108/files. However, I don't understand why yarn.lock isn't updated until now 🤔 