### PR TITLE
Avoid rendering children when none was provided

### DIFF
--- a/packages/react/src/host/RemoteComponent.tsx
+++ b/packages/react/src/host/RemoteComponent.tsx
@@ -64,6 +64,10 @@ export const RemoteComponent = memo(
 
     const {children} = attached;
 
+    if (children.length === 0) {
+      return <Implementation {...props} />;
+    }
+
     return (
       <Implementation {...props}>
         {renderChildren(children, receiver, controller)}


### PR DESCRIPTION
### Problem
During Hackdays, we noticed remote-ui did not fully support `<img />` tags. The underlying issue has to do with how remote-ui always converts children to an array. This becomes a problem when the host implementation of a remote component uses the spread syntax to forward props. Something like this:

```tsx
function HostImage(props) {
  return <img {...props} />;
}
```

Images must never have children to be valid html, so if they're provided an empty array as children, React will throw out an error: ```img is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML` ```

[Codesandbox](https://codesandbox.io/s/fast-browser-oqgq9)

