### PR TITLE
Store container reference to allow multiple render calls

### DIFF
--- a/documentation/guides/polyfills.md
+++ b/documentation/guides/polyfills.md
@@ -1,6 +1,6 @@
 # Polyfills
 
-The default builds of packages in this repo (the ones you’d get if you `require('@remote-ui/x')` or `import {} from '@remote-ui/x'`) include the polyfills necessary for that code to run. This is done to prevent accidentally shipping a feature based on remote-ui that fails in older browsers, which do not have some of the globals (like `WeakSet` or `Symbol`) that the libraries use internally. The polyfills are inlined with Babel.
+The default builds of packages in this repo (the ones you’d get if you `require('@remote-ui/x')` or `import {} from '@remote-ui/x'`) include the polyfills necessary for that code to run. This is done to prevent accidentally shipping a feature based on remote-ui that fails in older browsers, which do not have some of the globals (like `WeakSet`, `WeakMap`, or `Symbol`) that the libraries use internally. The polyfills are inlined with Babel.
 
 Some projects will have an existing conditional polyfilling setup that they may prefer to use. For example, at Shopify, we render multiple versions of our apps, targeting different browser groups, and we want all code (including as many of our apps’ dependencies as possible) to only have the minimal number of language features transpiled, and polyfills imported, for that browser support.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -48,6 +48,42 @@ render(<App />, remoteRoot);
 
 As you add, remove, and update host components in your React tree, this renderer will output those operations to the `RemoteRoot`. Since remote components are just a combination of a name and allowed properties, they map exactly to React components, which behave the same way.
 
+Updating the the root React element for a given remote root can be done by calling the `render()` function again. For example, the root React element can be updated in an effect to receive updated props when they change:
+
+```tsx
+import {useEffect, useMemo} from 'react';
+import {render, createRemoteRoot} from '@remote-ui/react';
+
+// A remote component
+const Button = createRemoteReactComponent<'Button', {onPress(): void}>(
+  'Button',
+);
+
+function App({count, onPress}: {count: number; onPress(): void}) {
+  return <Button onPress={onPress}>I was clicked {count} time(s)</Button>;
+}
+
+function MyRemoteRenderer() {
+  const remoteRoot = useMemo(() => {
+    // Assuming we get a function that will communicate with the host...
+    const channel = () => {};
+
+    return createRemoteRoot(channel, {
+      components: [Button],
+    });
+  }, []);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    // We update the root component by calling `render` whenever `count` changes
+    render(
+      <App count={count} onPress={() => setCount((count) => count + 1)} />,
+      remoteRoot,
+    );
+  }, [count, remoteRoot]);
+}
+```
+
 #### `createRemoteReactComponent()`
 
 In the example above, our `Button` component was not strongly typed. Like with [`@remote-ui/core`’s `createRemoteComponent`](../core#createremotecomponent), We can use the `createRemoteReactComponent` function from this library to create a strongly typed component to use. `@remote-ui/react`’s API is the exact same as `createRemoteComponent` (including the same type arguments), but the value returned is both a `RemoteComponentType` _and_ a `ReactComponentType`, both with appropriate prop types.

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,9 +1,13 @@
 import {createContext} from 'react';
 import type {RemoteRoot} from '@remote-ui/core';
 
-import type reconciler from './reconciler';
+import type {Reconciler} from './reconciler';
 
-export const RenderContext = createContext<{
+export interface RenderContextDescriptor {
   root: RemoteRoot;
-  reconciler: typeof reconciler;
-} | null>(null);
+  reconciler: Reconciler;
+}
+
+export const RenderContext = createContext<RenderContextDescriptor | null>(
+  null,
+);

--- a/packages/react/src/reconciler.ts
+++ b/packages/react/src/reconciler.ts
@@ -1,4 +1,4 @@
-import reactReconciler from 'react-reconciler';
+import reactReconciler, {Reconciler as ReactReconciler} from 'react-reconciler';
 import type {
   RemoteRoot,
   RemoteText,
@@ -6,33 +6,41 @@ import type {
   RemoteComponentType,
 } from '@remote-ui/core';
 
-const reconciler = reactReconciler<
-  // type
-  RemoteComponentType<string, any>,
-  // props
-  Record<string, unknown>,
-  // root container
+type Type = RemoteComponentType<string, any>;
+type Props = Record<string, unknown>;
+type ViewInstance = RemoteComponent<any, any>;
+type TextInstance = RemoteText<any>;
+type HostContext = Record<string, never>;
+type UpdatePayload = Record<string, unknown>;
+type SuspenseInstance = never;
+type PublicInstance = unknown;
+type HydratableInstance = unknown;
+type ChildSet = unknown;
+type TimeoutHandle = unknown;
+type NoTimeout = unknown;
+
+export type Reconciler = ReactReconciler<
   RemoteRoot,
-  // view instance
-  RemoteComponent<any, any>,
-  // text instance
-  RemoteText<any>,
-  // suspense instance
-  never,
-  // hydratable instance
-  unknown,
-  // public instance
-  unknown,
-  // host context
-  Record<string, never>,
-  // update payload
-  Record<string, unknown>,
-  // child set
-  unknown,
-  // timeout handle
-  unknown,
-  // notimeout
-  unknown
+  ViewInstance,
+  TextInstance,
+  SuspenseInstance,
+  PublicInstance
+>;
+
+export const reconciler = reactReconciler<
+  Type,
+  Props,
+  RemoteRoot,
+  ViewInstance,
+  TextInstance,
+  SuspenseInstance,
+  HydratableInstance,
+  PublicInstance,
+  HostContext,
+  UpdatePayload,
+  ChildSet,
+  TimeoutHandle,
+  NoTimeout
 >({
   now: Date.now,
 
@@ -173,5 +181,3 @@ const {hasOwnProperty} = {};
 function has(object: object, property: string | number | symbol) {
   return hasOwnProperty.call(object, property);
 }
-
-export default reconciler;

--- a/packages/react/src/render.tsx
+++ b/packages/react/src/render.tsx
@@ -1,26 +1,51 @@
 import type {ReactElement} from 'react';
+import type {RemoteRoot} from '@remote-ui/core';
+import type {RootTag} from 'react-reconciler';
 
-import reconciler from './reconciler';
+import {reconciler} from './reconciler';
+import type {Reconciler} from './reconciler';
 import {RenderContext} from './context';
+import type {RenderContextDescriptor} from './context';
+
+const cache = new WeakMap<
+  RemoteRoot,
+  {
+    container: ReturnType<Reconciler['createContainer']>;
+    renderContext: RenderContextDescriptor;
+  }
+>();
+
+// @see https://github.com/facebook/react/blob/993ca533b42756811731f6b7791ae06a35ee6b4d/packages/react-reconciler/src/ReactRootTags.js
+// I think we are a legacy root?
+const LEGACY_ROOT: RootTag = 0;
 
 export function render(
   element: ReactElement,
-  root: import('@remote-ui/core').RemoteRoot<any, any>,
+  root: RemoteRoot<any, any>,
   callback?: () => void,
 ) {
-  // @see https://github.com/facebook/react/blob/993ca533b42756811731f6b7791ae06a35ee6b4d/packages/react-reconciler/src/ReactRootTags.js
-  // I think we are a legacy root?
-  const container = reconciler.createContainer(root, 0, false, null);
+  // First, check if we've already cached a container and render context for this root
+  let cached = cache.get(root);
 
-  // Rule thinks we are in a React component, but we’re in a context that
-  // only creates this value once instead.
-  // eslint-disable-next-line react/jsx-no-constructed-context-values
-  const renderContextValue = {root, reconciler};
+  if (!cached) {
+    // Since we haven't created a container for this root yet, create a new one
+    const value = {
+      container: reconciler.createContainer(root, LEGACY_ROOT, false, null),
+      // We also cache the render context to avoid re-creating it on subsequent render calls
+      renderContext: {root, reconciler},
+    };
+
+    // Store the container and render context for retrieval on subsequent render calls
+    cache.set(root, value);
+    cached = value;
+  }
+
+  const {container, renderContext} = cached;
 
   // callback is cast here because the typings do not mark that argument
   // as optional, even though it is.
   reconciler.updateContainer(
-    <RenderContext.Provider value={renderContextValue}>
+    <RenderContext.Provider value={renderContext}>
       {element}
     </RenderContext.Provider>,
     container,


### PR DESCRIPTION
This PR stores the React Reconciler container associated to a remote root in a WeakMap.

Calling `render` multiple times is the only way to update the root React element. Without this change, calling `render` multiple times for the same root creates a new container on every invocation.