### PR TITLE
@remote-ui/testing: Fix an issue where find() and findAll() cannot find components with fragment props

### DIFF
--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where `find()` and `findAll()` couldn't find components with fragment props.
+
 ## [1.0.3] - 2020-06-24
 
 ### Fixed

--- a/packages/testing/loom.config.ts
+++ b/packages/testing/loom.config.ts
@@ -6,5 +6,5 @@ export default createPackage((pkg) => {
   pkg.runtimes(Runtime.Node);
   pkg.entry({root: './src/index.ts'});
   pkg.entry({name: 'matchers', root: './src/matchers/index.ts'});
-  pkg.use(defaultProjectPlugin());
+  pkg.use(defaultProjectPlugin({react: true}));
 });

--- a/packages/testing/src/mount.ts
+++ b/packages/testing/src/mount.ts
@@ -60,11 +60,26 @@ export function mount<Root extends RemoteRoot<any, any> = RemoteRoot<any, any>>(
       ];
     }
 
+    const getTypeString = (type: any) => {
+      // Components that have fragment props are put into a ComponentWrapper which makes their
+      // `type` an object rather than a string. This function grabs the `displayName` string from
+      // that object so that `find` works.
+      if (
+        typeof type === 'object' &&
+        type?.type?.name === 'ComponentWrapper' &&
+        type?.type?.displayName
+      ) {
+        return type.type.displayName;
+      }
+
+      return type;
+    };
+
     const find: Node<Props>['find'] = (type, props) =>
       (descendants.find(
         (element) =>
           isNode(element) &&
-          element.type === type &&
+          element.type === getTypeString(type) &&
           (props == null ||
             equalSubset(props, element.props as Record<string, unknown>)),
       ) as any) ?? null;
@@ -89,7 +104,7 @@ export function mount<Root extends RemoteRoot<any, any> = RemoteRoot<any, any>>(
         descendants.filter(
           (element) =>
             isNode(element) &&
-            element.type === type &&
+            element.type === getTypeString(type) &&
             (props == null ||
               equalSubset(props, element.props as Record<string, unknown>)),
         ) as any,

--- a/packages/testing/tests/mount.test.tsx
+++ b/packages/testing/tests/mount.test.tsx
@@ -1,0 +1,36 @@
+import type {RemoteFragment} from '@remote-ui/core';
+
+import {mount} from '../src';
+import {render, createRemoteReactComponent} from '../../react/src';
+
+const StandardComponent =
+  createRemoteReactComponent<'StandardComponent'>('StandardComponent');
+
+const FragmentPropsComponent = createRemoteReactComponent<
+  'FragmentPropsComponent',
+  {someProp: RemoteFragment}
+>('FragmentPropsComponent', {
+  fragmentProps: ['someProp'],
+});
+
+describe('mount()', () => {
+  it('find() and findAll() are able to find a standard component', () => {
+    const wrapper = mount((root) => render(<StandardComponent />, root));
+
+    expect(wrapper.find(StandardComponent)).not.toBeNull();
+
+    expect(wrapper.findAll(StandardComponent)[0]).toBeDefined();
+    expect(wrapper.findAll(StandardComponent)[0]).not.toBeNull();
+  });
+
+  it('find() and findAll() are able to find a component with fragment props', () => {
+    const wrapper = mount((root) =>
+      render(<FragmentPropsComponent someProp={<></>} />, root),
+    );
+
+    expect(wrapper.find(FragmentPropsComponent)).not.toBeNull();
+
+    expect(wrapper.findAll(FragmentPropsComponent)[0]).toBeDefined();
+    expect(wrapper.findAll(FragmentPropsComponent)[0]).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Components with fragment props are wrapped in a `ComponentWrapper`, so they don't import as strings, which is what the `find()` and `findAll()` test methods are expecting (see [the relevant code](https://github.com/jt-stripe/remote-ui/blob/main/packages/react/src/components.tsx#L24-L27)). This adds a `getTypeString` function that returns the `type.displayName` if the component is wrapped in a `ComponentWrapper`.

I've added tests for this as well—the first set of tests in the `testing` package.