### PR TITLE
Remove unnecessary useReceiver() and useController() hooks from the React library

### DIFF
--- a/packages/react/src/host/context.ts
+++ b/packages/react/src/host/context.ts
@@ -1,9 +1,0 @@
-import {createContext} from 'react';
-
-export const ControllerContext = createContext<
-  import('./types').Controller | null
->(null);
-
-export const RemoteReceiverContext = createContext<
-  import('@remote-ui/core').RemoteReceiver | null
->(null);

--- a/packages/react/src/host/hooks.ts
+++ b/packages/react/src/host/hooks.ts
@@ -1,27 +1,5 @@
-import {useState, useDebugValue, useContext, useEffect} from 'react';
+import {useState, useDebugValue, useEffect} from 'react';
 import type {RemoteReceiver, RemoteReceiverAttachable} from '@remote-ui/core';
-
-import {ControllerContext, RemoteReceiverContext} from './context';
-
-export function useController() {
-  const controller = useContext(ControllerContext);
-
-  if (controller == null) {
-    throw new Error('No remote-ui Controller instance found in context');
-  }
-
-  return controller;
-}
-
-export function useRemoteReceiver() {
-  const receiver = useContext(RemoteReceiverContext);
-
-  if (receiver == null) {
-    throw new Error('No remote-ui Receiver instance found in context');
-  }
-
-  return receiver;
-}
 
 interface State<T extends RemoteReceiverAttachable> {
   receiver: RemoteReceiver;

--- a/packages/react/src/host/index.ts
+++ b/packages/react/src/host/index.ts
@@ -11,6 +11,4 @@ export type {
   ReactPropsFromRemoteComponentType,
   ReactComponentTypeFromRemoteComponentType,
 } from '../types';
-export {RemoteReceiverContext, ControllerContext} from './context';
-export {useRemoteReceiver, useAttached} from './hooks';
 export type {Controller, RemoteComponentProps, RemoteTextProps} from './types';


### PR DESCRIPTION
https://github.com/Shopify/remote-ui/issues/142 asked what the purpose of the `useReceiver()` and `useController()` APIs was. The answer was "nothing" — these utilities were used by the library in earlier versions, but are no longer used internally, and have no real value externally. This PR removes them.