### PR TITLE
Pass File directly through postMessage

### DIFF
--- a/packages/rpc/src/encoding/basic.ts
+++ b/packages/rpc/src/encoding/basic.ts
@@ -59,7 +59,7 @@ export function createBasicEncoder(api: EncodingStrategyApi): EncodingStrategy {
 
   function encode(value: unknown): [any, Transferable[]?] {
     if (typeof value === 'object') {
-      if (value == null) {
+      if (value == null || value instanceof File) {
         return [value];
       }
 
@@ -105,6 +105,10 @@ export function createBasicEncoder(api: EncodingStrategyApi): EncodingStrategy {
     if (typeof value === 'object') {
       if (value == null) {
         return value as any;
+      }
+
+      if (value instanceof File) {
+        return value;
       }
 
       if (Array.isArray(value)) {


### PR DESCRIPTION
When passing parameters across postMessage, any `File` was seen as an object and thus transferred as an empty object `{}`.

[Some objects](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types) are supported by postMessage, including `File`, so we added support to send those natively.