### PR TITLE
allow ArrayBuffer to be sent over rpc layer

### DIFF
--- a/packages/rpc/CHANGELOG.md
+++ b/packages/rpc/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow `ArrayBuffer` to be sent over the rpc layer ([pull request](https://github.com/Shopify/remote-ui/pull/147)).
+
 ## [1.2.6] - 2022-01-25
 
 - Stopped throwing an error in some `postMessage` event handlers, which prevents unhandled promise rejection listeners from running unnecessarily.

--- a/packages/rpc/src/encoding/basic.ts
+++ b/packages/rpc/src/encoding/basic.ts
@@ -63,6 +63,10 @@ export function createBasicEncoder(api: EncodingStrategyApi): EncodingStrategy {
         return [value];
       }
 
+      if (value instanceof ArrayBuffer) {
+        return [value];
+      }
+
       const transferables: Transferable[] = [];
 
       if (Array.isArray(value)) {
@@ -105,6 +109,10 @@ export function createBasicEncoder(api: EncodingStrategyApi): EncodingStrategy {
     if (typeof value === 'object') {
       if (value == null) {
         return value as any;
+      }
+
+      if (value instanceof ArrayBuffer) {
+        return value;
       }
 
       if (Array.isArray(value)) {


### PR DESCRIPTION
 In https://github.com/Shopify/remote-ui/pull/146, @mathieulag and I were looking at being able to use `File`s as function parameters. @lemonmade rightfully pointed out that `File` is a web only api and `@remote-ui/rpc` shouldn't rely on web only APIs.

In this attempt we're using and transferring ArrayBuffers which can be used to construct `File`s and can also be extracted from a `File` object. 

We were also looking into using a `FileLike` object when communicating between the worker and the main page and ways to convert these to and from `File` for usage with 3rd party code that relies on `File`.

```ts

  interface FileLike {
    metadata: {
      name: string;
      lastModified: number;
      type: string;
    };
    content: ArrayBuffer;
  }
```

With this approach, the sending side will always lose ownership of the `ArrayBuffer`, which may be surprising to developers. 

To mitigate this, we could ensure to always provide APIs on the worker side, which ["clone"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice) the buffer before actually passing it. 

Alternatively, we could also not transfer the `ArrayBuffer`, although this would come with a performance hit: https://developers.google.com/web/updates/2011/12/Transferable-Objects-Lightning-Fast

Which may actually be less severe than cloning the `ArrayBuffer` every time.
