### PR TITLE
Improve renderComponent() utility in React to make "position in tree" restrictions a little easier

### DIFF
--- a/packages/core/src/receiver.ts
+++ b/packages/core/src/receiver.ts
@@ -8,6 +8,7 @@ import {
   ACTION_UPDATE_TEXT,
   KIND_COMPONENT,
   KIND_FRAGMENT,
+  KIND_ROOT,
 } from './types';
 import type {
   ActionArgumentMap,
@@ -38,6 +39,7 @@ export interface RemoteReceiverAttachableFragment
 
 export interface RemoteReceiverAttachableRoot {
   id: typeof ROOT_ID;
+  kind: typeof KIND_ROOT;
   children: RemoteReceiverAttachableChild[];
   version: number;
 }
@@ -111,6 +113,7 @@ export function createRemoteReceiver(): RemoteReceiver {
 
   const root: RemoteReceiverAttachableRoot = {
     id: ROOT_ID,
+    kind: KIND_ROOT,
     children: [],
     version: 0,
   };

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -270,9 +270,9 @@ function MyRemoteRenderer() {
 - The `receiver` (`RemoteReceiver`) object that is tracking updates to the remote root
 - The `controller` object that is being created
 
-This function is also called with `renderDefault()` function that will perform the default logic of rendering the React component with a matching name that you provided as the first argument to `createController`.
+This function is also called with a `renderDefault()` function. That function will return the result of rendering the React component with a matching name that you provided as the first argument to `createController`. You can use this function to conditionally apply the “default” logic, while applying your special logic to other cases.
 
-The following example shows how you can use this fine-grained control to only allow a `Modal` component at the “root” of a remote tree, but to allow all other components to be rendered lower in the tree:
+The following example shows how you can use this fine-grained control. In this example, a `Modal` component is only allowed at the “root” of a remote tree, but all components _other_ than `Modal` can be rendered as nested components:
 
 ```tsx
 import {KIND_ROOT} from '@remote-ui/core';

--- a/packages/react/src/host/RemoteRenderer.tsx
+++ b/packages/react/src/host/RemoteRenderer.tsx
@@ -13,7 +13,8 @@ export const RemoteRenderer = memo(function RemoteRenderer({
   controller,
   receiver,
 }: RemoteRendererProps) {
-  const {children} = useAttached(receiver, receiver.attached.root)!;
+  const {root} = receiver.attached;
+  const {children} = useAttached(receiver, root)!;
   const {renderComponent, renderText} = controller.renderer;
 
   return (
@@ -22,6 +23,7 @@ export const RemoteRenderer = memo(function RemoteRenderer({
         switch (child.kind) {
           case KIND_COMPONENT:
             return renderComponent({
+              parent: root,
               component: child,
               receiver,
               controller,
@@ -29,6 +31,7 @@ export const RemoteRenderer = memo(function RemoteRenderer({
             });
           case KIND_TEXT:
             return renderText({
+              parent: root,
               text: child,
               receiver,
               key: child.id,

--- a/packages/react/src/host/RemoteText.tsx
+++ b/packages/react/src/host/RemoteText.tsx
@@ -3,10 +3,6 @@ import {memo} from 'react';
 import type {RemoteTextProps} from './types';
 import {useAttached} from './hooks';
 
-export function renderText({text, receiver, key}: RemoteTextProps) {
-  return <RemoteText key={key} text={text} receiver={receiver} />;
-}
-
 export const RemoteText = memo(function RemoteText({
   text,
   receiver,

--- a/packages/react/src/host/controller.tsx
+++ b/packages/react/src/host/controller.tsx
@@ -8,8 +8,8 @@ import type {
   Renderer,
   RenderTextOptions,
 } from './types';
-import {renderComponent as defaultRenderComponent} from './RemoteComponent';
-import {renderText as defaultRenderText} from './RemoteText';
+import {RemoteComponent} from './RemoteComponent';
+import {RemoteText} from './RemoteText';
 
 export interface ComponentMapping {
   [key: string]: ComponentType<any>;
@@ -31,6 +31,25 @@ export function createController(
   }: Partial<RendererFactory> = {},
 ): Controller {
   const registry = new Map(Object.entries(components));
+
+  const defaultRenderComponent: Renderer['renderComponent'] = ({
+    parent,
+    component,
+    controller,
+    receiver,
+    key,
+  }) => {
+    return (
+      <RemoteComponent
+        parent={parent}
+        component={component}
+        controller={controller}
+        receiver={receiver}
+        key={key}
+      />
+    );
+  };
+
   const renderComponent: Renderer['renderComponent'] = externalRenderComponent
     ? (componentProps) =>
         externalRenderComponent(componentProps, {
@@ -39,6 +58,18 @@ export function createController(
           },
         })
     : defaultRenderComponent;
+
+  const defaultRenderText: Renderer['renderText'] = ({
+    key,
+    receiver,
+    text,
+    parent,
+  }) => {
+    return (
+      <RemoteText key={key} receiver={receiver} text={text} parent={parent} />
+    );
+  };
+
   const renderText: Renderer['renderText'] = externalRenderText
     ? (textProps) =>
         externalRenderText(textProps, {

--- a/packages/react/src/host/controller.tsx
+++ b/packages/react/src/host/controller.tsx
@@ -15,7 +15,7 @@ export interface ComponentMapping {
   [key: string]: ComponentType<any>;
 }
 
-interface RendererFactory {
+export interface ControllerOptions {
   renderComponent(
     props: RemoteComponentProps,
     options: RenderComponentOptions,
@@ -28,7 +28,7 @@ export function createController(
   {
     renderComponent: externalRenderComponent,
     renderText: externalRenderText,
-  }: Partial<RendererFactory> = {},
+  }: Partial<ControllerOptions> = {},
 ): Controller {
   const registry = new Map(Object.entries(components));
 

--- a/packages/react/src/host/index.ts
+++ b/packages/react/src/host/index.ts
@@ -6,7 +6,7 @@ export type {RemoteRendererProps} from './RemoteRenderer';
 export {RemoteComponent} from './RemoteComponent';
 export {RemoteText} from './RemoteText';
 export {createController} from './controller';
-export type {ComponentMapping} from './controller';
+export type {ComponentMapping, ControllerOptions} from './controller';
 export type {
   ReactPropsFromRemoteComponentType,
   ReactComponentTypeFromRemoteComponentType,

--- a/packages/react/src/host/types.ts
+++ b/packages/react/src/host/types.ts
@@ -1,6 +1,7 @@
 import type {ComponentType, ReactNode} from 'react';
 import type {
   RemoteReceiver,
+  RemoteReceiverAttachableRoot,
   RemoteReceiverAttachableComponent,
   RemoteReceiverAttachableText,
   RemoteComponentType,
@@ -8,6 +9,7 @@ import type {
 } from '@remote-ui/core';
 
 export interface RemoteTextProps {
+  parent: RemoteReceiverAttachableRoot | RemoteReceiverAttachableComponent;
   text: RemoteReceiverAttachableText;
   receiver: RemoteReceiver;
   key: string | number;
@@ -15,6 +17,7 @@ export interface RemoteTextProps {
 
 export interface RemoteComponentProps {
   receiver: RemoteReceiver;
+  parent: RemoteReceiverAttachableRoot | RemoteReceiverAttachableComponent;
   component: RemoteReceiverAttachableComponent;
   controller: Controller;
   key: string | number;
@@ -22,6 +25,7 @@ export interface RemoteComponentProps {
 
 export interface RemoteFragmentProps {
   receiver: RemoteReceiver;
+  parent: RemoteReceiverAttachableComponent;
   fragment: RemoteReceiverAttachableFragment;
   controller: Controller;
 }


### PR DESCRIPTION
This PR adds a new field to the `renderComponent()` function we introduced in https://github.com/Shopify/remote-ui/pull/86. The new field is `parent`, which gives the host the ability to easily customize behavior based on what other component is rendering this one. This is particularly useful if you want to enforce some components being allowed as direct children of the remote root, and others only being allowed if they are nested below the root.

We never added documentation to `renderComponent()`, so I have done that here.

cc/ @js-goupil this adds what I think is the missing piece for easily implementing more advanced component restrictions on the host, if you are interested in doing that instead of a multi-extension point setup.