### PR TITLE
Prevent installations of react-reconciler greater than 0.26.2

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,6 +42,6 @@
     "@remote-ui/rpc": "^1.3.0",
     "@types/react": ">=17.0.0 <18.0.0",
     "@types/react-reconciler": "^0.26.0",
-    "react-reconciler": ">=0.26.0 <1.0.0"
+    "react-reconciler": ">=0.26.0 <0.27.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8813,7 +8813,7 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-"react-reconciler@>=0.26.0 <1.0.0", react-reconciler@^0.26.0:
+"react-reconciler@>=0.26.0 <0.27.0", react-reconciler@^0.26.0:
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
   integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==


### PR DESCRIPTION
Hey remote-ui team 👋 

TL;DR: Tests are broken in this repository in the `react` package (and dependent projects) with a fresh `yarn.lock` file because of a new version of `react-reconciler`.

Steps to reproduce:
- Check out a clean copy of the `main` branch
- Delete `yarn.lock`
- Run `yarn install`
- Run `yarn test packages/react/src/tests/e2e.test.tsx`

Error: `TypeError: Cannot read property 'isBatchingLegacy' of undefined`
<details>
<summary>Stacktrace</summary>

```
      45 |   // callback is cast here because the typings do not mark that argument
      46 |   // as optional, even though it is.
    > 47 |   reconciler.updateContainer(
         |              ^
      48 |     <RenderContext.Provider value={renderContext}>
      49 |       {element}
      50 |     </RenderContext.Provider>,

      at ensureRootIsScheduled (../../node_modules/react-reconciler/cjs/react-reconciler.development.js:17721:35)
      at scheduleUpdateOnFiber (../../node_modules/react-reconciler/cjs/react-reconciler.development.js:17572:5)
      at Object.updateContainer (../../node_modules/react-reconciler/cjs/react-reconciler.development.js:20950:14)
      at render (src/render.tsx:47:14)
      at src/tests/e2e.test.tsx:238:7
      at batchedUpdates$1 (../../node_modules/react-dom/cjs/react-dom.development.js:22380:12)
      at act (../../node_modules/react-dom/cjs/react-dom-test-utils.development.js:1042:14)
      at Object.<anonymous> (src/tests/e2e.test.tsx:236:5)
      at TestScheduler.scheduleTests (../../node_modules/@jest/core/build/TestScheduler.js:333:13)
      at runJest (../../node_modules/@jest/core/build/runJest.js:404:19)
```

</details>



A new version of `react-reconciler` came out recently (version `0.27.0`), and it [only supports React 18+](https://github.com/facebook/react/blob/main/packages/react-reconciler/package.json#L29). `@remote-ui` currently supports React 17 only.

The `react-reconciler` [docs state](https://github.com/facebook/react/blob/main/packages/react-reconciler/README.md?plain=1#L5):
> Its API is not as stable as that of React, React Native, or React DOM, and does not follow the common versioning scheme.

This explains why they've included a breaking change in a minor version update.

To fix the issue, I suggest that we lock `react-reconciler` to version `0.26.2` (the last version before `0.27.0`) or less.