### PR TITLE
Remove deprecated folder path mapping in `exports` field

### DIFF
--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -22,7 +22,6 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./": "./",
     "./browser": {
       "esnext": "./browser.esnext",
       "import": "./browser.mjs",

--- a/packages/mini-react/package.json
+++ b/packages/mini-react/package.json
@@ -35,7 +35,6 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./": "./",
     "./compat": {
       "esnext": "./compat.esnext",
       "import": "./compat.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,6 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./": "./",
     "./host": {
       "esnext": "./host.esnext",
       "import": "./host.mjs",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -23,7 +23,6 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./": "./",
     "./matchers": {
       "esnext": "./matchers.esnext",
       "import": "./matchers.mjs",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -24,7 +24,6 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./": "./",
     "./host": {
       "esnext": "./host.esnext",
       "import": "./host.mjs",


### PR DESCRIPTION
This PR removes the deprecated `"./": "./"` path mappings in the `exports` field inside `package.json`.

Link to official deprecation notice in node: 607d48e7987200fa084d1864a95374ab5cd93373