### PR TITLE
Add a failing test to showcase duplicate node bug

### DIFF
--- a/packages/react/src/tests/e2e.test.tsx
+++ b/packages/react/src/tests/e2e.test.tsx
@@ -417,49 +417,6 @@ describe('@remote-ui/react', () => {
   });
 
   describe('Remote tree updates', () => {
-    it('updates the remote tree when setting state with an array', () => {
-      const receiver = createRemoteReceiver();
-      const remoteRoot = createRemoteRoot(receiver.receive, {
-        components: [RemoteBox],
-      });
-
-      function RemoteApp() {
-        const [items, setItems] = useState(['a', 'b', 'c']);
-        const handleClick = useCallback(() => {
-          setItems((prev) => prev.reverse());
-        }, []);
-        return (
-          <RemoteBox id="click-target" onClick={handleClick}>
-            {items.map((item) => (
-              <RemoteBox key={item}>{item}</RemoteBox>
-            ))}
-          </RemoteBox>
-        );
-      }
-
-      const controller = createController({Box: HostBox});
-
-      function HostApp() {
-        return <RemoteRenderer controller={controller} receiver={receiver} />;
-      }
-
-      domAct(() => {
-        domRender(<HostApp />, appElement);
-        render(<RemoteApp />, remoteRoot, () => {
-          remoteRoot.mount();
-        });
-        jest.runAllTimers();
-        Simulate.click(appElement.querySelector('#click-target')!);
-        jest.runAllTimers();
-      });
-
-      const children = appElement.querySelector('#click-target')!.childNodes;
-      expect(children).toHaveLength(3);
-      expect(children[0].textContent).toBe('c');
-      expect(children[1].textContent).toBe('b');
-      expect(children[2].textContent).toBe('a');
-    });
-
     it('renders the expected items after state updates', () => {
       const receiver = createRemoteReceiver();
       const remoteRoot = createRemoteRoot(receiver.receive, {
@@ -468,10 +425,8 @@ describe('@remote-ui/react', () => {
 
       function RemoteApp() {
         const [items, setItems] = useState(['a', 'b', 'c']);
-        const [, setNum] = useState(0);
         const handleClick = useCallback(() => {
-          setItems((prev) => prev.reverse());
-          setNum((prev) => prev + 1);
+          setItems(['c', 'b', 'a']);
         }, []);
         return (
           <RemoteBox id="click-target" onClick={handleClick}>


### PR DESCRIPTION
# Add failing tests
This adds some failing tests to showcase what seems like a bug in remote-ui to me.

In the first test, we create a remote app that calls the `useState` hook with an array.  We then call `setState` with a new array, reversing the items.  However, the remote tree does not render as expected afterwards.  It seems that calling `setState` with an array does not re-render the component.

The issue raised in the second test may be related.  It is similar to the first test, except it also uses state of a number to reliably re-render the remote tree.  After re-rendering, we find that list items have been duplicated and 5 child nodes are present instead of 3.