### PR TITLE
Fix more remote node reordering issues

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,6 +41,7 @@ export interface ActionArgumentMap {
     Id | undefined,
     number,
     RemoteTextSerialization | RemoteComponentSerialization,
+    Id | undefined | false,
   ];
   [ACTION_REMOVE_CHILD]: [Id | undefined, number];
   [ACTION_UPDATE_TEXT]: [Id, string];

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -6,7 +6,10 @@ type PropsForRemoteComponent<T> = T extends RemoteComponentType<
   infer Props,
   any
 >
-  ? {[K in keyof Props]: RemoteFragmentToReactElement<Props[K]>}
+  ? Props extends Record<string, never>
+    ? // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
+    : {[K in keyof Props]: RemoteFragmentToReactElement<Props[K]>}
   : never;
 
 type RemoteFragmentToReactElement<T> = T extends RemoteFragment<infer R>


### PR DESCRIPTION
My previous fix in https://github.com/Shopify/remote-ui/pull/160 only covered a subset of the reordering bugs in remote-ui. There were two other issues that caused problems in other cases:

1. We were not sending the correct index to `appendChildBefore()` in cases where the child was moving to a larger index in `children` in the same parent as it was already attached
2. We were not replicating the "append starts by removing from an existing node" behavior in the `RemoteRoot` object.

This PR fixes both of those issues. The code is a little gnarly and I feel like I could do the whole "map remote root to remote receiver" much more cleanly if I started from scratch, but it appears to fix the reordering bugs that the last PR did not.