### PR TITLE
Normalize new node props

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed a nested node prop rendering bug in the receiver ([pull request](https://github.com/Shopify/remote-ui/pull/168))
 
 ## [2.1.12] - 2021-06-15
 

--- a/packages/core/src/receiver.ts
+++ b/packages/core/src/receiver.ts
@@ -229,7 +229,7 @@ export function createRemoteReceiver(): RemoteReceiver {
           detach(oldProp);
         }
         if (isRemoteFragmentSerialization(newProp)) {
-          const attachableNewProp = addVersion(newProp);
+          const attachableNewProp = normalizeNode(newProp, addVersion);
           attach(attachableNewProp);
         }
       });


### PR DESCRIPTION
Normalizes nodes with `addVersion` so newly rendered props with nested fragment children can render.

This will help us fix a user-reported issue: https://github.com/stripe/stripe-apps/issues/641