### PR TITLE
@remote-ui/testing: Fix debug to filter props according to all option

### DIFF
--- a/packages/testing/src/print.ts
+++ b/packages/testing/src/print.ts
@@ -22,21 +22,30 @@ export function nodeChildToString<Props>(
 
   const name = nodeName(node);
   const indent = '  '.repeat(level);
-  const props = Object.keys(node.props).reduce<string[]>((list, key) => {
-    if (!key) {
+  const props = Object.keys(node.props)
+    // filter out insigificiant properties unless all option is present
+    .filter((key) => {
+      if (options.all) {
+        return true;
+      }
+
+      return !/^(className)$|^(aria|data)-/.test(key);
+    })
+    .reduce<string[]>((list, key) => {
+      if (!key) {
+        return list;
+      }
+
+      const value = (node.props as any)[key];
+
+      if (value === undefined && !options.all) {
+        return list;
+      }
+
+      list.push(toPropString(key, value, options.verbosity));
+
       return list;
-    }
-
-    const value = (node.props as any)[key];
-
-    if (value === undefined && !options.all) {
-      return list;
-    }
-
-    list.push(toPropString(key, value, options.verbosity));
-
-    return list;
-  }, []);
+    }, []);
 
   const hasChildren = node.children.length > 0;
 


### PR DESCRIPTION
The object returned from `mount` has a `debug` method that is supposed to accept an `all` option according to the linked [@shopify/react-testing docs](https://github.com/Shopify/quilt/tree/main/packages/react-testing#-debugoptions-allprops-boolean-depth-number-verbosity-number-string) (This option is actually called `allProps` in `@shopify/react-testing` which is  potentially confusing). This adds the filtering behavior described in the docs so that `className`, `aria-*`, and `data-*` prop names are omitted by default, but included it the `{ all: true }` option is passed in.