### PR TITLE
add allow-same-origin to demo iframe sandbox attribute

### DIFF
--- a/examples/vanilla-dom/app/index.html
+++ b/examples/vanilla-dom/app/index.html
@@ -43,7 +43,7 @@
     -->
     <iframe
       src="./remote.html"
-      sandbox="allow-scripts"
+      sandbox="allow-same-origin allow-scripts"
       style="visibility: hidden; position: absolute;"
     ></iframe>
 


### PR DESCRIPTION
Running the demo was erroring without this additional value in the `sandbox` attribute.