### PR TITLE
Ensure render errors are logged inside a worker

### DIFF
--- a/packages/react/src/error-polyfill.ts
+++ b/packages/react/src/error-polyfill.ts
@@ -1,0 +1,24 @@
+// Make the react build believe that it is running in a page context,
+// otherwise react rendering errors won't be logged. This code MUST
+// be in the global scope, to ensure that it is run before react
+// initializes. This is especially important when bundlers are used
+// which will re-order modules by execution priority.
+//
+// React logic we're working around:
+// https://github.com/facebook/react/blob/4e6eec69be632c0c0177c5b1c8a70397d92ee181/packages/shared/invokeGuardedCallbackImpl.js#L53-L237
+if (!('window' in globalThis) && !('document' in globalThis)) {
+  class FakeDocument {
+    createEvent(type: string) {
+      return new Event(type);
+    }
+
+    createElement() {
+      return new EventTarget();
+    }
+  }
+
+  globalThis.window = globalThis as any;
+  globalThis.document = new FakeDocument() as any;
+}
+
+export {};

--- a/packages/react/src/render.tsx
+++ b/packages/react/src/render.tsx
@@ -15,6 +15,24 @@ const cache = new WeakMap<
   }
 >();
 
+// Make the react build believe that it is running in a page context,
+// otherwise react rendering errors won't be logged. See:
+// https://github.com/facebook/react/blob/4e6eec69be632c0c0177c5b1c8a70397d92ee181/packages/shared/invokeGuardedCallbackImpl.js#L53-L237
+if (!('window' in globalThis) && !('document' in globalThis)) {
+  class FakeDocument {
+    createEvent(type: string) {
+      return new Event(type);
+    }
+
+    createElement() {
+      return new EventTarget();
+    }
+  }
+
+  globalThis.window = globalThis as any;
+  globalThis.document = new FakeDocument() as any;
+}
+
 // @see https://github.com/facebook/react/blob/993ca533b42756811731f6b7791ae06a35ee6b4d/packages/react-reconciler/src/ReactRootTags.js
 // I think we are a legacy root?
 const LEGACY_ROOT: RootTag = 0;

--- a/packages/react/src/render.tsx
+++ b/packages/react/src/render.tsx
@@ -1,3 +1,4 @@
+import './error-polyfill';
 import type {ReactElement} from 'react';
 import type {RemoteRoot} from '@remote-ui/core';
 import type {RootTag} from 'react-reconciler';
@@ -14,24 +15,6 @@ const cache = new WeakMap<
     renderContext: RenderContextDescriptor;
   }
 >();
-
-// Make the react build believe that it is running in a page context,
-// otherwise react rendering errors won't be logged. See:
-// https://github.com/facebook/react/blob/4e6eec69be632c0c0177c5b1c8a70397d92ee181/packages/shared/invokeGuardedCallbackImpl.js#L53-L237
-if (!('window' in globalThis) && !('document' in globalThis)) {
-  class FakeDocument {
-    createEvent(type: string) {
-      return new Event(type);
-    }
-
-    createElement() {
-      return new EventTarget();
-    }
-  }
-
-  globalThis.window = globalThis as any;
-  globalThis.document = new FakeDocument() as any;
-}
 
 // @see https://github.com/facebook/react/blob/993ca533b42756811731f6b7791ae06a35ee6b4d/packages/react-reconciler/src/ReactRootTags.js
 // I think we are a legacy root?


### PR DESCRIPTION
This works around a limitation in React's development build. Before logging errors to the console it checks if they are in a page context. If not, then they won't show the error at all. The changes here stub out the properties React checks for to trick them into logging errors.

See: https://github.com/facebook/react/blob/4e6eec69be632c0c0177c5b1c8a70397d92ee181/packages/shared/invokeGuardedCallbackImpl.js#L53-L237

Despite best efforts, I'm not sure why the order of the error messages are reversed. Normally the error is logged first and then immediately followed by the component stack trace. In either way I think showing an error rather than showing none at all is preferable, even if the order is not correct.

Screenshot:

<img width="720" alt="react-error" src="https://user-images.githubusercontent.com/1062408/189919380-619fcc25-aad3-44f8-b8e9-4344d9c022b1.png">
