### PR TITLE
Fix react error-polyfill missing in dist files

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,6 @@
       "require": "./host.js"
     }
   },
-  "sideEffects": false,
   "devDependencies": {
     "@types/react-dom": "^17.0.0",
     "react": "^17.0.0",


### PR DESCRIPTION
@misha-reyzlin-shopify noticed that the changes from #178 weren't present in the packaged files. After a bit of debugging we noticed that `sideEffects: false` was set in `package.json` which drops any top-level code that is deemed to have side-effects. Simply removing that setting fixes it.