### PR TITLE
Add back sideEffect to only list effectful files

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,6 +29,9 @@
       "require": "./host.js"
     }
   },
+  "sideEffects": [
+    "./src/error-polyfill.ts"
+  ],
   "devDependencies": {
     "@types/react-dom": "^17.0.0",
     "react": "^17.0.0",


### PR DESCRIPTION
This fixes it in the same way as #179 .

See: https://github.com/Shopify/remote-ui/pull/179#issuecomment-1249545034