### PR TITLE
Add dist side-effectful files too

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,6 +30,9 @@
     }
   },
   "sideEffects": [
+    "./build/cjs/error-polyfill.cjs",
+    "./build/esm/error-polyfill.mjs",
+    "./build/esnext/error-polyfill.esnext",
     "./src/error-polyfill.ts"
   ],
   "devDependencies": {


### PR DESCRIPTION
Note, the source file must still be present, otherwise the `build` command will strip it.