### PR TITLE
Only patch window in a worker context

### DIFF
--- a/packages/react/src/error-polyfill.ts
+++ b/packages/react/src/error-polyfill.ts
@@ -6,7 +6,14 @@
 //
 // React logic we're working around:
 // https://github.com/facebook/react/blob/4e6eec69be632c0c0177c5b1c8a70397d92ee181/packages/shared/invokeGuardedCallbackImpl.js#L53-L237
-if (!('window' in globalThis) && !('document' in globalThis)) {
+//
+// On top of that we also need to ensure that we only patch it when
+// not running inside a worker
+if (
+  'importScripts' in globalThis &&
+  !('window' in globalThis) &&
+  !('document' in globalThis)
+) {
   class FakeDocument {
     createEvent(type: string) {
       return new Event(type);


### PR DESCRIPTION
Reason for this is that there is too much code that checks against `window` to determine if it runs in the browser or not. But this breaks our testing setup.