### PR TITLE
Avoid verifying the state of the iframe by accessing contentDocument

### DIFF
--- a/packages/rpc/src/adaptors/iframe-child.ts
+++ b/packages/rpc/src/adaptors/iframe-child.ts
@@ -9,6 +9,20 @@ export function fromInsideIframe({targetOrigin = '*'} = {}): MessageEndpoint {
 
   const {parent} = self;
 
+  const ready = () => parent.postMessage('remote-ui::ready', targetOrigin);
+
+  // Listening to `readyState` in iframe, though the child iframe could probably
+  // send a `postMessage` that it is ready to receive messages sooner than that.
+  if (document.readyState === 'complete') {
+    ready();
+  } else {
+    document.addEventListener('readystatechange', () => {
+      if (document.readyState === 'complete') {
+        ready();
+      }
+    });
+  }
+
   // We need to store the listener, because we wrap it to do some origin checking. Ideally,
   // we’d instead store an `AbortController`, and use its signal to cancel the listeners,
   // but that isn’t widely supported.

--- a/packages/rpc/src/adaptors/iframe-parent.ts
+++ b/packages/rpc/src/adaptors/iframe-parent.ts
@@ -18,20 +18,17 @@ export function fromIframe(
     (event: MessageEvent) => void
   >();
 
-  const iframeLoadPromise =
-    target.contentDocument?.readyState === 'complete'
-      ? Promise.resolve()
-      : new Promise<void>((resolve) => {
-          target.addEventListener('load', () => resolve(), {
-            once: true,
-          });
-        });
+  const iframeReadyPromise = new Promise<void>((resolve) => {
+    window.addEventListener('message', (event) => {
+      if ((event as MessageEvent).data === 'remote-ui::ready') {
+        resolve();
+      }
+    });
+  });
 
   return {
     async postMessage(message, transfer) {
-      if (target.contentDocument?.readyState !== 'complete') {
-        await iframeLoadPromise;
-      }
+      await iframeReadyPromise;
 
       target.contentWindow!.postMessage(message, targetOrigin, transfer);
     },


### PR DESCRIPTION
# Summary
Avoid verifying the state of the iframe by accessing `target.contentDocument` but instead rely postMessage to indicate a ready state.

# Details
When the RPC is used on an iframe that has the `sandbox` attribute, Safari would log Sandbox access violation due the way we verified that the iframe was ready to interact with and send messages to the parent.

# Solution
The `fromInsideIframe` emits a `postMessage('remote-ui::ready')` when the iframe `readystatechange` is `complete`. The `fromIframe` listens to the `postMessage('remote-ui::ready')` and resolve the `iframeReadyPromise`.