### PR TITLE
Fix some infinite loops

### DIFF
--- a/.changeset/thirty-insects-work.md
+++ b/.changeset/thirty-insects-work.md
@@ -1,0 +1,6 @@
+---
+'@remote-ui/core': patch
+'@remote-ui/rpc': patch
+---
+
+Fix infinite loops with self-referencing structures

--- a/packages/core/src/root.ts
+++ b/packages/core/src/root.ts
@@ -634,11 +634,7 @@ function tryHotSwappingValues(
     return result;
   }
 
-  if (
-    typeof currentValue === 'object' &&
-    currentValue != null &&
-    !isRemoteFragment(currentValue)
-  ) {
+  if (isBasicObject(currentValue) && !isRemoteFragment(currentValue)) {
     seen.set(currentValue, [IGNORE]);
 
     const result = tryHotSwappingObjectValues(currentValue, newValue, seen);
@@ -690,7 +686,7 @@ function makeValueHotSwappable(
     }
 
     return result;
-  } else if (typeof value === 'object' && value != null) {
+  } else if (isBasicObject(value)) {
     const result: Record<string, any> = {};
     seen.set(value, result);
 
@@ -1089,7 +1085,7 @@ function tryHotSwappingObjectValues(
   newValue: unknown,
   seen: WeakMap<any, HotSwapResult>,
 ): HotSwapResult {
-  if (typeof newValue !== 'object' || newValue == null) {
+  if (!isBasicObject(newValue) || Array.isArray(newValue)) {
     return [
       makeValueHotSwappable(newValue),
       collectNestedHotSwappableValues(currentValue)?.map(
@@ -1214,4 +1210,12 @@ function tryHotSwappingArrayValues(
   }
 
   return [hasChanged ? normalizedNewValue : IGNORE, hotSwaps];
+}
+
+function isBasicObject(value: unknown): value is object {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
 }

--- a/packages/core/src/tests/root.test.ts
+++ b/packages/core/src/tests/root.test.ts
@@ -290,7 +290,7 @@ describe('root', () => {
       expect(secondActionFuncOne).toHaveBeenCalled();
     });
 
-    it.only('can handle recursive hot swapping', async () => {
+    it('can handle recursive hot swapping', async () => {
       const funcOne = jest.fn();
       const objectOne = {func: funcOne};
       Reflect.defineProperty(objectOne, 'self', {
@@ -312,7 +312,7 @@ describe('root', () => {
         complexProp: objectOne,
       });
 
-      root.appendChild(button);
+      root.append(button);
       root.mount();
 
       // After this, the receiver will have the initial Button component

--- a/packages/core/src/tests/root.test.ts
+++ b/packages/core/src/tests/root.test.ts
@@ -290,7 +290,7 @@ describe('root', () => {
       expect(secondActionFuncOne).toHaveBeenCalled();
     });
 
-    it('can handle recursive hot swapping', async () => {
+    it.only('can handle recursive hot swapping', async () => {
       const funcOne = jest.fn();
       const objectOne = {func: funcOne};
       Reflect.defineProperty(objectOne, 'self', {
@@ -301,7 +301,7 @@ describe('root', () => {
       const funcTwo = jest.fn();
       const objectTwo = {func: funcTwo};
       Reflect.defineProperty(objectTwo, 'self', {
-        value: objectTwo,
+        value: [],
         enumerable: true,
       });
 
@@ -318,9 +318,13 @@ describe('root', () => {
       // After this, the receiver will have the initial Button component
       receiver.flush();
 
-      expect(
-        await button.updateProps({complexProp: objectTwo}),
-      ).toBeUndefined();
+      await button.updateProps({complexProp: objectTwo});
+
+      const currentProp = (receiver.children[0] as any).props.complexProp;
+      currentProp.func();
+
+      expect(funcOne).not.toHaveBeenCalled();
+      expect(funcTwo).toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/tests/root.test.ts
+++ b/packages/core/src/tests/root.test.ts
@@ -289,6 +289,39 @@ describe('root', () => {
 
       expect(secondActionFuncOne).toHaveBeenCalled();
     });
+
+    it('can handle recursive hot swapping', async () => {
+      const funcOne = jest.fn();
+      const objectOne = {func: funcOne};
+      Reflect.defineProperty(objectOne, 'self', {
+        value: objectOne,
+        enumerable: true,
+      });
+
+      const funcTwo = jest.fn();
+      const objectTwo = {func: funcTwo};
+      Reflect.defineProperty(objectTwo, 'self', {
+        value: objectTwo,
+        enumerable: true,
+      });
+
+      const receiver = createDelayedReceiver();
+
+      const root = createRemoteRoot(receiver.receive);
+      const button = root.createComponent('Button', {
+        complexProp: objectOne,
+      });
+
+      root.appendChild(button);
+      root.mount();
+
+      // After this, the receiver will have the initial Button component
+      receiver.flush();
+
+      expect(
+        await button.updateProps({complexProp: objectTwo}),
+      ).toBeUndefined();
+    });
   });
 });
 

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -11,6 +11,8 @@ export {
   retain,
   release,
   StackFrame,
+  isBasicObject,
+  isMemoryManageable,
   RELEASE_METHOD,
   RETAIN_METHOD,
   RETAINED_BY,

--- a/packages/rpc/src/memory.ts
+++ b/packages/rpc/src/memory.ts
@@ -102,7 +102,7 @@ export function releaseInternal(
       seen.set(value, nestedCanRelease);
 
       return nestedCanRelease;
-    } else if (typeof value === 'object' && value != null) {
+    } else if (Object.getPrototypeOf(value) === Object.prototype) {
       const nestedCanRelease = Object.keys(value).reduce<boolean>(
         (canRelease, key) =>
           releaseInternal(value[key], deep, seen) || canRelease,


### PR DESCRIPTION
This PR prevents a few infinite loops that could happen in `@remote-ui` packages related to iterating over potentially self-referencing structures. This came up in a few different places:

- In `@remote-ui/core`, we try to "hot swap" function properties so that updates to functions need to be sent over the RPC bridge less often. This "hot swapping" is done recursively for props that are objects or arrays.
- In `@remote-ui/rpc`, we provide a `retain` and `release` method that will iterate through deeply nested objects to retain all nested functions.