### PR TITLE
Allow custom React reconciler in remote-ui/react

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,3 +8,5 @@ export type {
   ReactPropsFromRemoteComponentType,
   ReactComponentTypeFromRemoteComponentType,
 } from './types';
+export {createReconciler} from './reconciler';
+export type {Reconciler} from './reconciler';

--- a/packages/react/src/reconciler.ts
+++ b/packages/react/src/reconciler.ts
@@ -1,4 +1,7 @@
-import reactReconciler, {Reconciler as ReactReconciler} from 'react-reconciler';
+import reactReconciler, {
+  Reconciler as ReactReconciler,
+  HostConfig,
+} from 'react-reconciler';
 import type {
   RemoteRoot,
   RemoteText,
@@ -27,148 +30,166 @@ export type Reconciler = ReactReconciler<
   PublicInstance
 >;
 
-export const reconciler = reactReconciler<
-  Type,
-  Props,
-  RemoteRoot,
-  ViewInstance,
-  TextInstance,
-  SuspenseInstance,
-  HydratableInstance,
-  PublicInstance,
-  HostContext,
-  UpdatePayload,
-  ChildSet,
-  TimeoutHandle,
-  NoTimeout
->({
-  now: Date.now,
+export const createReconciler = (
+  hostConfig?: HostConfig<
+    Type,
+    Props,
+    RemoteRoot,
+    ViewInstance,
+    TextInstance,
+    SuspenseInstance,
+    HydratableInstance,
+    PublicInstance,
+    HostContext,
+    UpdatePayload,
+    ChildSet,
+    TimeoutHandle,
+    NoTimeout
+  >,
+) =>
+  reactReconciler<
+    Type,
+    Props,
+    RemoteRoot,
+    ViewInstance,
+    TextInstance,
+    SuspenseInstance,
+    HydratableInstance,
+    PublicInstance,
+    HostContext,
+    UpdatePayload,
+    ChildSet,
+    TimeoutHandle,
+    NoTimeout
+  >({
+    now: Date.now,
 
-  // Timeout
-  scheduleTimeout: setTimeout,
-  cancelTimeout: clearTimeout,
-  noTimeout: false,
-  // @see https://github.com/facebook/react/blob/master/packages/react-dom/src/client/ReactDOMHostConfig.js#L408
-  queueMicrotask: (callback) =>
-    Promise.resolve(null).then(callback).catch(handleErrorInNextTick),
+    // Timeout
+    scheduleTimeout: setTimeout,
+    cancelTimeout: clearTimeout,
+    noTimeout: false,
+    // @see https://github.com/facebook/react/blob/master/packages/react-dom/src/client/ReactDOMHostConfig.js#L408
+    queueMicrotask: (callback) =>
+      Promise.resolve(null).then(callback).catch(handleErrorInNextTick),
 
-  isPrimaryRenderer: true,
-  supportsMutation: true,
-  supportsHydration: false,
-  supportsPersistence: false,
+    isPrimaryRenderer: true,
+    supportsMutation: true,
+    supportsHydration: false,
+    supportsPersistence: false,
 
-  // Context
-  getRootHostContext() {
-    return {};
-  },
-  getChildHostContext(context) {
-    return context;
-  },
+    // Context
+    getRootHostContext() {
+      return {};
+    },
+    getChildHostContext(context) {
+      return context;
+    },
 
-  // Instances
-  createTextInstance(text, root) {
-    return root.createText(text);
-  },
-  createInstance(type, allProps, root) {
-    const {children: _children, ...props} = allProps;
-    return root.createComponent(type, props);
-  },
+    // Instances
+    createTextInstance(text, root) {
+      return root.createText(text);
+    },
+    createInstance(type, allProps, root) {
+      const {children: _children, ...props} = allProps;
+      return root.createComponent(type, props);
+    },
 
-  // Updates
-  commitTextUpdate(text, _oldText, newText) {
-    text.updateText(newText);
-  },
-  prepareUpdate(_instance, _type, oldProps, newProps) {
-    const updateProps: Record<string, unknown> = {};
-    let needsUpdate = false;
+    // Updates
+    commitTextUpdate(text, _oldText, newText) {
+      text.updateText(newText);
+    },
+    prepareUpdate(_instance, _type, oldProps, newProps) {
+      const updateProps: Record<string, unknown> = {};
+      let needsUpdate = false;
 
-    for (const key in oldProps) {
-      if (!has(oldProps, key) || key === 'children') {
-        continue;
+      for (const key in oldProps) {
+        if (!has(oldProps, key) || key === 'children') {
+          continue;
+        }
+
+        if (!(key in newProps)) {
+          needsUpdate = true;
+          updateProps[key] = undefined;
+          // } else if (typeof oldProps[key] === 'function') {
+          //   if (typeof newProps[key] === 'function') {
+          //     fragment.controller.functions.exchange(
+          //       oldProps[key] as Function,
+          //       newProps[key] as Function,
+          //     );
+          //   } else {
+          //     needsUpdate = true;
+          //     fragment.controller.functions.revoke(oldProps[key] as Function);
+          //     updateProps[key] = newProps[key];
+          //   }
+        } else if (oldProps[key] !== newProps[key]) {
+          needsUpdate = true;
+          updateProps[key] = newProps[key];
+        }
       }
 
-      if (!(key in newProps)) {
-        needsUpdate = true;
-        updateProps[key] = undefined;
-        // } else if (typeof oldProps[key] === 'function') {
-        //   if (typeof newProps[key] === 'function') {
-        //     fragment.controller.functions.exchange(
-        //       oldProps[key] as Function,
-        //       newProps[key] as Function,
-        //     );
-        //   } else {
-        //     needsUpdate = true;
-        //     fragment.controller.functions.revoke(oldProps[key] as Function);
-        //     updateProps[key] = newProps[key];
-        //   }
-      } else if (oldProps[key] !== newProps[key]) {
-        needsUpdate = true;
-        updateProps[key] = newProps[key];
-      }
-    }
+      for (const key in newProps) {
+        if (!has(newProps, key) || key === 'children') {
+          continue;
+        }
 
-    for (const key in newProps) {
-      if (!has(newProps, key) || key === 'children') {
-        continue;
+        if (!(key in oldProps)) {
+          needsUpdate = true;
+          updateProps[key] = newProps[key];
+        }
       }
 
-      if (!(key in oldProps)) {
-        needsUpdate = true;
-        updateProps[key] = newProps[key];
-      }
-    }
+      return needsUpdate ? updateProps : null;
+    },
+    commitUpdate(instance, payload) {
+      instance.updateProps(payload);
+    },
 
-    return needsUpdate ? updateProps : null;
-  },
-  commitUpdate(instance, payload) {
-    instance.updateProps(payload);
-  },
-
-  // Update root
-  appendChildToContainer(remoteRoot, child) {
-    remoteRoot.appendChild(child);
-  },
-  insertInContainerBefore(remoteRoot, child, beforeChild) {
-    remoteRoot.insertChildBefore(child, beforeChild);
-  },
-  removeChildFromContainer(remoteRoot, child) {
-    remoteRoot.removeChild(child);
-  },
-  clearContainer(remoteRoot) {
-    for (const child of remoteRoot.children) {
+    // Update root
+    appendChildToContainer(remoteRoot, child) {
+      remoteRoot.appendChild(child);
+    },
+    insertInContainerBefore(remoteRoot, child, beforeChild) {
+      remoteRoot.insertChildBefore(child, beforeChild);
+    },
+    removeChildFromContainer(remoteRoot, child) {
       remoteRoot.removeChild(child);
-    }
-  },
+    },
+    clearContainer(remoteRoot) {
+      for (const child of remoteRoot.children) {
+        remoteRoot.removeChild(child);
+      }
+    },
 
-  // Update children
-  appendInitialChild(parent, child) {
-    parent.appendChild(child);
-  },
-  appendChild(parent, child) {
-    parent.appendChild(child);
-  },
-  insertBefore(parent, newChild, beforeChild) {
-    parent.insertChildBefore(newChild, beforeChild);
-  },
-  removeChild(parent, child) {
-    parent.removeChild(child);
-  },
+    // Update children
+    appendInitialChild(parent, child) {
+      parent.appendChild(child);
+    },
+    appendChild(parent, child) {
+      parent.appendChild(child);
+    },
+    insertBefore(parent, newChild, beforeChild) {
+      parent.insertChildBefore(newChild, beforeChild);
+    },
+    removeChild(parent, child) {
+      parent.removeChild(child);
+    },
 
-  // Unknown
-  finalizeInitialChildren() {
-    return false;
-  },
-  shouldSetTextContent() {
-    return false;
-  },
-  getPublicInstance() {},
-  prepareForCommit() {
-    return null;
-  },
-  resetAfterCommit() {},
-  commitMount() {},
-  preparePortalMount() {},
-});
+    // Unknown
+    finalizeInitialChildren() {
+      return false;
+    },
+    shouldSetTextContent() {
+      return false;
+    },
+    getPublicInstance() {},
+    prepareForCommit() {
+      return null;
+    },
+    resetAfterCommit() {},
+    commitMount() {},
+    preparePortalMount() {},
+    ...hostConfig,
+  });
 
 function handleErrorInNextTick(error: Error) {
   setTimeout(() => {

--- a/packages/react/src/reconciler.ts
+++ b/packages/react/src/reconciler.ts
@@ -1,7 +1,4 @@
-import reactReconciler, {
-  Reconciler as ReactReconciler,
-  HostConfig,
-} from 'react-reconciler';
+import reactReconciler, {Reconciler as ReactReconciler} from 'react-reconciler';
 import type {
   RemoteRoot,
   RemoteText,
@@ -30,23 +27,7 @@ export type Reconciler = ReactReconciler<
   PublicInstance
 >;
 
-export const createReconciler = (
-  hostConfig?: HostConfig<
-    Type,
-    Props,
-    RemoteRoot,
-    ViewInstance,
-    TextInstance,
-    SuspenseInstance,
-    HydratableInstance,
-    PublicInstance,
-    HostContext,
-    UpdatePayload,
-    ChildSet,
-    TimeoutHandle,
-    NoTimeout
-  >,
-) =>
+export const createReconciler = (options?: {primary?: boolean}) =>
   reactReconciler<
     Type,
     Props,
@@ -72,7 +53,7 @@ export const createReconciler = (
     queueMicrotask: (callback) =>
       Promise.resolve(null).then(callback).catch(handleErrorInNextTick),
 
-    isPrimaryRenderer: true,
+    isPrimaryRenderer: options?.primary ?? true,
     supportsMutation: true,
     supportsHydration: false,
     supportsPersistence: false,
@@ -188,7 +169,6 @@ export const createReconciler = (
     resetAfterCommit() {},
     commitMount() {},
     preparePortalMount() {},
-    ...hostConfig,
   });
 
 function handleErrorInNextTick(error: Error) {

--- a/packages/react/src/render.tsx
+++ b/packages/react/src/render.tsx
@@ -2,7 +2,7 @@ import type {ReactElement} from 'react';
 import type {RemoteRoot} from '@remote-ui/core';
 import type {RootTag} from 'react-reconciler';
 
-import {reconciler} from './reconciler';
+import {createReconciler} from './reconciler';
 import type {Reconciler} from './reconciler';
 import {RenderContext} from './context';
 import type {RenderContextDescriptor} from './context';
@@ -18,11 +18,13 @@ const cache = new WeakMap<
 // @see https://github.com/facebook/react/blob/993ca533b42756811731f6b7791ae06a35ee6b4d/packages/react-reconciler/src/ReactRootTags.js
 // I think we are a legacy root?
 const LEGACY_ROOT: RootTag = 0;
+const defaultReconciler = createReconciler();
 
 export function render(
   element: ReactElement,
   root: RemoteRoot<any, any>,
   callback?: () => void,
+  reconciler: Reconciler = defaultReconciler,
 ) {
   // First, check if we've already cached a container and render context for this root
   let cached = cache.get(root);


### PR DESCRIPTION
## What is this solving ?

In some cases, it's possible to have a remote-ui setup where there is two primary renderers on the remote, one for the main content on the remote and one for the components being rendered and sent to the host.

With this kind of setup, React will throw an error when the same context provider is used with both renderers. This is due to the fact that React only supports having one primary renderer and one secondary renderer concurrently. Some unexpected behaviour can occur from this and React will also log warnings to the console.

Here's a reproduction of this exact issue using an iframe which renders content and also attempts to render components on the host (the main webpage here). The shared context provider here is a `RecoilRoot` from [recoil](https://github.com/facebookexperimental/Recoil) and is used only as an example of a library that could be used in more than one environment.

https://stackblitz.com/edit/vitejs-vite-qmh2qb?file=src%2Fremote.tsx

<img width="900" alt="image" src="https://user-images.githubusercontent.com/17585917/203884676-0b717c04-7cce-4a70-b75e-40da07579b3a.png">

## How is it solving the issue ?

In cases like this, we need to tell remote-ui's reconciler that it is being used as a secondary renderer. React's reconciler package accepts an option called [isPrimaryRenderer](https://github.com/facebook/react/tree/main/packages/react-reconciler#isprimaryrenderer) that allows us to do just that.

In order to let consumers customize their React reconciler as they see fit, this PR does the following:
* Add a `reconciler` parameter to `render` (remote-ui/react)
* Expose a `createReconciler` function to create a reconciler which defaults to our existing configuration.

Ultimately, this allows consumers to create a reconciler like this:

```tsx
const reconciler = createReconciler({isPrimaryRenderer: false});

// and eventually use the reconciler
render(<>{children}</>, root, root.mount, reconciler);
```

## Notes
* There is no test coverage around the React reconciler, so I haven't added extra test for this change which is pretty straightforward. Happy to look into it if we are worried about the change.
* I'm not sure how much flexibility we want to expose to consumers. I've exposed the full host config for developers to customize, but we might want to restrict it. I'm all ears for feedback and suggestions on this.
