### PR TITLE
React 18, take 2

### DIFF
--- a/.changeset/moody-gorillas-compare.md
+++ b/.changeset/moody-gorillas-compare.md
@@ -1,0 +1,5 @@
+---
+'@remote-ui/react': major
+---
+
+Added support for React 18 by having the consumer own the versions of `react` and `react-reconciler`. If you are currently using React 17 only, and are rendering in the “remote” context, you will need to add a dependency on `react-reconciler^0.27.0`. If you are using React 18, you will need to manually install the version of `react-reconciler` that matches up to that version (currently, `^0.29.0`).

--- a/.changeset/yellow-maps-own.md
+++ b/.changeset/yellow-maps-own.md
@@ -1,0 +1,5 @@
+---
+'@remote-ui/react': major
+---
+
+Removed re-export of `@remote-ui/rpc`. If you need `retain` or `release`, import them directly from `@remote-ui/rpc` instead.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -18,6 +18,17 @@
   - @remote-ui/core@2.2.0
   - @remote-ui/rpc@1.4.0
 
+## [5.0.0] - 2022-11-25
+
+### Breaking changes
+
+- Added support for React 18 by having the consumer own the versions of `react` and `react-reconciler`. If you are currently using React 17 only, and are rendering in the “remote” context, you will need to add a dependency on `react-reconciler^0.27.0`. If you are using React 18, you will need to manually install the version of `react-reconciler` that matches up to that version (currently, `^0.29.0`).
+- Removed re-export of `@remote-ui/rpc`. If you need `retain` or `release`, import them directly from `@remote-ui/rpc` instead.
+
+### Deprecated
+
+- The `render` function is deprecated. Please move to using the new `createRoot` instead, which matches the API provided by React.
+
 ## [4.5.1] - 2022-05-16
 
 - Fixed a missing `useAttached()` export in the `@shopify/remote-ui/host` entrypoint.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -18,13 +18,6 @@
   - @remote-ui/core@2.2.0
   - @remote-ui/rpc@1.4.0
 
-## [5.0.0] - 2022-11-25
-
-### Breaking changes
-
-- Added support for React 18 by having the consumer own the versions of `react` and `react-reconciler`. If you are currently using React 17 only, and are rendering in the “remote” context, you will need to add a dependency on `react-reconciler^0.27.0`. If you are using React 18, you will need to manually install the version of `react-reconciler` that matches up to that version (currently, `^0.29.0`).
-- Removed re-export of `@remote-ui/rpc`. If you need `retain` or `release`, import them directly from `@remote-ui/rpc` instead.
-
 ### Deprecated
 
 - The `render` function is deprecated. Please move to using the new `createRoot` instead, which matches the API provided by React.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,16 +31,28 @@
   },
   "sideEffects": false,
   "devDependencies": {
-    "@types/react-dom": "^17.0.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "@types/react-dom": "^18.0.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-reconciler": "^0.29.0"
   },
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.13",
     "@remote-ui/core": "^2.2.0",
     "@remote-ui/rpc": "^1.4.0",
-    "@types/react": ">=17.0.0 <18.0.0",
-    "@types/react-reconciler": "^0.26.0",
-    "react-reconciler": ">=0.26.0 <0.27.0"
+    "@types/react": ">=17.0.0 <19.0.0",
+    "@types/react-reconciler": ">=0.26.0 <0.30.0"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0 <19.0.0",
+    "react-reconciler": ">=0.26.0 <0.30.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": false
+    },
+    "react-reconciler": {
+      "optional": true
+    }
   }
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,7 @@
-export {retain, release} from '@remote-ui/rpc';
 export {createRemoteRoot} from '@remote-ui/core';
 export type {RemoteRoot, RemoteReceiver} from '@remote-ui/core';
-export {render} from './render';
+export {render, createRoot} from './render';
+export type {Root} from './render';
 export {createRemoteReactComponent} from './components';
 export {useRemoteSubscription} from './hooks';
 export type {

--- a/packages/react/src/tests/e2e.test.tsx
+++ b/packages/react/src/tests/e2e.test.tsx
@@ -1,7 +1,8 @@
 /* eslint @shopify/jsx-no-hardcoded-content: off */
 
-import {useEffect, useContext, createContext, useState} from 'react';
-import {render as domRender} from 'react-dom';
+import {useEffect, useContext, useState, createContext} from 'react';
+import {createRoot as createDOMRoot} from 'react-dom/client';
+import type {Root} from 'react-dom/client';
 import {act as domAct, Simulate} from 'react-dom/test-utils';
 import {
   KIND_ROOT,
@@ -13,10 +14,14 @@ import type {RemoteFragment, PropsForRemoteComponent} from '@remote-ui/core';
 import {RemoteRenderer, createController} from '../host';
 import type {ControllerOptions} from '../host';
 import {
-  render,
+  createRoot,
   createRemoteReactComponent,
   ReactPropsFromRemoteComponentType,
 } from '..';
+
+// Tell react to enable `act()` behaviour. See:
+// https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#configuring-your-testing-environment
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 const RemoteHelloWorld = createRemoteReactComponent<
   'HelloWorld',
@@ -97,14 +102,21 @@ function HostWithFragment({
 
 describe('@remote-ui/react', () => {
   let appElement!: HTMLElement;
+  let domRoot: Root;
 
   beforeEach(() => {
     appElement = document.createElement('div');
     document.body.append(appElement);
+    domAct(() => {
+      domRoot = createDOMRoot(appElement);
+    });
     jest.useFakeTimers();
   });
 
   afterEach(() => {
+    domAct(() => {
+      domRoot.unmount();
+    });
     appElement.remove();
     jest.useRealTimers();
   });
@@ -128,10 +140,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -168,10 +179,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -200,15 +210,13 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(
+      domRoot.render(
         <PersonContext.Provider value={person}>
           <HostApp />
         </PersonContext.Provider>,
-        appElement,
       );
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -234,10 +242,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
     expect(appElement.innerHTML).toBe(`<img src="https://shopify.com">`);
@@ -262,10 +269,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
     expect(appElement.innerHTML).toBe('hello');
@@ -317,10 +323,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -388,10 +393,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -457,10 +461,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -519,10 +522,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -581,10 +583,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -641,10 +642,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -708,10 +708,9 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
@@ -761,7 +760,13 @@ describe('@remote-ui/react', () => {
               )
             }
           />
-          <RemoteButton onPress={() => setShow(true)}>Show</RemoteButton>
+          <RemoteButton
+            onPress={() => {
+              setShow(true);
+            }}
+          >
+            Show
+          </RemoteButton>
         </>
       );
     }
@@ -777,16 +782,18 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
     expect(appElement.innerHTML).toBe(`<button type="button">Show</button>`);
 
     domAct(() => {
       Simulate.click(appElement.querySelector('button')!);
+    });
+
+    domAct(() => {
       jest.runAllTimers();
     });
 
@@ -833,15 +840,17 @@ describe('@remote-ui/react', () => {
     }
 
     domAct(() => {
-      domRender(<HostApp />, appElement);
-      render(<RemoteApp />, remoteRoot, () => {
-        remoteRoot.mount();
-      });
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
       jest.runAllTimers();
     });
 
     domAct(() => {
       Simulate.click(appElement.querySelector('button')!);
+    });
+
+    domAct(() => {
       jest.runAllTimers();
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,17 +1976,17 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-dom@^17.0.0":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.1.tgz#d92d77d020bfb083e07cc8e0ac9f933599a4d56a"
-  integrity sha512-yIVyopxQb8IDZ7SOHeTovurFq+fXiPICa+GV3gp0Xedsl+MwQlMLKmvrnEjFbQxjliH5YVAEWFh975eVNmKj7Q==
+"@types/react-dom@^18.0.5":
+  version "18.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
+  integrity sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==
   dependencies:
     "@types/react" "*"
 
-"@types/react-reconciler@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.26.0.tgz#fee923cb6621e6817ab4b84ad0f64707e4670a07"
-  integrity sha512-kWnVUzDqUkvibnYaLGH251qE9+HHhklA18Fuj556dvbb4atzPDrU2F3+Xpmlt4NuoEwYbWLJSnk/YKGeqN9Acg==
+"@types/react-reconciler@>=0.26.0 <0.30.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.0.tgz#513acbed173140e958c909041ca14eb40412077f"
+  integrity sha512-5cjk9ottZAj7eaTsqzPUIlrVbh3hBAO2YaEL1rkjHKB3xNAId7oU8GhzvAX+gfmlfoxTwJnBjPxEHyxkEA1Ffg==
   dependencies:
     "@types/react" "*"
 
@@ -1997,10 +1997,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=17.0.0 <18.0.0":
-  version "17.0.14"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
-  integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==
+"@types/react@*", "@types/react@>=17.0.0 <19.0.0":
+  version "18.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.25.tgz#8b1dcd7e56fe7315535a4af25435e0bb55c8ae44"
+  integrity sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2702,9 +2702,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001286:
-  version "1.0.30001435"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz"
-  integrity sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==
+  version "1.0.30001434"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz"
+  integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -6076,14 +6076,13 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-react-dom@^17.0.0:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
-  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.1"
+    scheduler "^0.23.0"
 
 "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
@@ -6095,7 +6094,7 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-"react-reconciler@>=0.26.0 <0.27.0", react-reconciler@^0.26.0:
+react-reconciler@^0.26.0:
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
   integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
@@ -6103,6 +6102,14 @@ react-is@^16.13.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-reconciler@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.29.0.tgz#ee769bd362915076753f3845822f2d1046603de7"
+  integrity sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.23.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -6122,13 +6129,12 @@ react-test-renderer@^17.0.0:
     react-shallow-renderer "^16.13.1"
     scheduler "^0.20.2"
 
-react@^17.0.0:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -6367,13 +6373,20 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.1, scheduler@^0.20.2:
+scheduler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
   integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+  dependencies:
+    loose-envify "^1.1.0"
 
 secure-compare@3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This PR is an updated version of @marvinhagemeister's original upgrade in https://github.com/Shopify/remote-ui/pull/157. After thinking about that PR a bunch, I couldn't come up with a way to resolve the issue of needing to declare an explicit dependency on `react-reconciler` as part of `@remote-ui/react`, since `react-reconciler` has had breaking change version bumps between the version that supports React 17, and the one supporting React 18.

The main changes I made as part of this PR were to introduce a breaking change that lets us support React 17 and 18, but which requires the consumer of the package to take on the `react-reconciler` dependency directly. I've added documentation about what versions of what packages a given developer will need in the README. This is a breaking change because the developer needs to add an additional dependency they did not need before.

Note that this `react-reconciler` dependency is only needed for ”remote” usage of remote-ui — a host application does not use the custom reconciler, and so does not ever import `react-reconciler` through `@remote-ui/react`.

I think this is the best thing we can do that gives us a progressive upgrade path, while unblocking consumers who want to use React 18 on the remote side (and avoiding duplicate dependencies for those who use React 18 on the host side).

I published these changes in `5.0.0-alpha.1` and it worked correctly for me. I didn't stress React 18+ features like Suspense, but the rest all seems to work as expected, with no warnings.