### PR TITLE
docs: Clarify react and react-reconciler dep requirements by version

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -30,14 +30,14 @@ yarn add react@^17.0.0 react-reconciler@^0.27.0
 npm install react@^17.0.0 react-reconciler@^0.27.0 --save
 ```
 
-**React 17.0.0 and later**: you will need to have React installed. Additionally, if you are in the “remote” environment, you will need a dependency on `react-reconciler` between greater than or equal to `0.28.0`:
+**React 18.x.x and later**: you will need to have React installed. Additionally, if you are in the “remote” environment, you will need a dependency on `react-reconciler` greater than or equal to `0.28.0`:
 
 ```
-yarn add react react-reconciler
+yarn add react@^18.0.0 react-reconciler@^0.28.0
 
 # or, with `npm`:
 
-npm install react react-reconciler --save
+npm install react@^18.0.0 react-reconciler@^0.28.0 --save
 ```
 
 If you are only using the utilities for [React host applications](#host-environment), you do not need to declare a dependency on `react-reconciler`.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -33,11 +33,11 @@ npm install react@^17.0.0 react-reconciler@^0.27.0 --save
 **React 18.x.x and later**: you will need to have React installed. Additionally, if you are in the “remote” environment, you will need a dependency on `react-reconciler` greater than or equal to `0.28.0`:
 
 ```
-yarn add react@^18.0.0 react-reconciler@^0.28.0
+yarn add react@^18.0.0 react-reconciler@">=0.28.0"
 
 # or, with `npm`:
 
-npm install react@^18.0.0 react-reconciler@^0.28.0 --save
+npm install react@^18.0.0 react-reconciler@">=0.28.0" --save
 ```
 
 If you are only using the utilities for [React host applications](#host-environment), you do not need to declare a dependency on `react-reconciler`.


### PR DESCRIPTION
### Context:

I noticed what seemed to be a typo about the React peer dependency version requirements in the README, referencing 17.x where it should be 18.x. While updating that, I also noticed the install commands for the latest version `@5.0.0` weren't specifying a specific dep versions, so I added those too. 

I'm not sure if this is helpful or not, so disregard if not :)


### Changes included:

 - Update documented dependency version requirements for `react` and `react-reconciler` for latest v5 release
