### PR TITLE
fix: Add missing React 18 reconciler function

### DIFF
--- a/.changeset/four-rivers-destroy.md
+++ b/.changeset/four-rivers-destroy.md
@@ -1,5 +1,5 @@
 ---
-'@remote-ui/react': minor
+'@remote-ui/react': patch
 ---
 
 Added missing `detachDeletedInstance` function to `@remote-ui/react/reconciler`. This function is invoked during React's clean up phase, so prior to this change you'd get an exception / broken app when a component is removed from the tree.

--- a/.changeset/four-rivers-destroy.md
+++ b/.changeset/four-rivers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@remote-ui/react': minor
+---
+
+Added missing `detachDeletedInstance` function to `@remote-ui/react/reconciler`. This function is invoked during React's clean up phase, so prior to this change you'd get an exception / broken app when a component is removed from the tree.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - [#191](https://github.com/Shopify/remote-ui/pull/191) [`77ba3da`](https://github.com/Shopify/remote-ui/commit/77ba3da217cb0e443e674afc058916ca25f5900e) Thanks [@lemonmade](https://github.com/lemonmade)! - Removed re-export of `@remote-ui/rpc`. If you need `retain` or `release`, import them directly from `@remote-ui/rpc` instead.
 
+### Patch Changes
+
+- Added missing `detachDeletedInstance` function to `@remote-ui/react/reconciler`. This function is invoked during React's clean up phase, so prior to this change you'd get an exception / broken app when a component is removed from the tree.
+
 ## 4.6.0
 
 ### Minor Changes

--- a/packages/react/src/reconciler.ts
+++ b/packages/react/src/reconciler.ts
@@ -181,6 +181,7 @@ export const createReconciler = (options?: {primary?: boolean}) =>
     resetAfterCommit() {},
     commitMount() {},
     preparePortalMount() {},
+    detachDeletedInstance() {},
   });
 
 function scheduleMicrotask(callback: () => void) {

--- a/packages/react/src/tests/e2e.test.tsx
+++ b/packages/react/src/tests/e2e.test.tsx
@@ -856,4 +856,50 @@ describe('@remote-ui/react', () => {
 
     expect(appElement.innerHTML).toContain('bac');
   });
+
+  it('handles removal of components that have unmounted', () => {
+    const receiver = createRemoteReceiver();
+    const remoteRoot = createRemoteRoot(receiver.receive, {
+      components: [RemoteImage, RemoteButton],
+    });
+
+    function RemoteApp() {
+      const [showImage, setShowImage] = useState(true);
+
+      return (
+        <>
+          {showImage && <RemoteImage data-test-id="image" />}
+          <RemoteButton onPress={() => setShowImage((prev) => !prev)}>
+            Toggle image
+          </RemoteButton>
+        </>
+      );
+    }
+
+    const controller = createController({
+      Button: HostButton,
+      Image: HostImage,
+    });
+
+    function HostApp() {
+      return <RemoteRenderer controller={controller} receiver={receiver} />;
+    }
+
+    domAct(() => {
+      domRoot.render(<HostApp />);
+      createRoot(remoteRoot).render(<RemoteApp />);
+      remoteRoot.mount();
+      jest.runAllTimers();
+    });
+
+    domAct(() => {
+      Simulate.click(appElement.querySelector('button')!);
+    });
+
+    domAct(() => {
+      jest.runAllTimers();
+    });
+
+    expect(appElement.innerHTML).not.toContain('data-test-id="image"');
+  });
 });

--- a/packages/react/src/tests/e2e.test.tsx
+++ b/packages/react/src/tests/e2e.test.tsx
@@ -857,7 +857,7 @@ describe('@remote-ui/react', () => {
     expect(appElement.innerHTML).toContain('bac');
   });
 
-  it('handles removal of components that have unmounted', () => {
+  it('handles removal & cleanup of unmounted components', () => {
     const receiver = createRemoteReceiver();
     const remoteRoot = createRemoteRoot(receiver.receive, {
       components: [RemoteImage, RemoteButton],


### PR DESCRIPTION
### Context

This adds a missing `detachDeletedInstance` function to `@remote-ui/react/reconciler`, which is [invoked during React's clean up phase](https://github.com/facebook/react/blob/d9e0485c84b45055ba86629dc20870faca9b5973/packages/react-reconciler/src/ReactFiberCommitWork.js#L1681-L1690). Prior to this change you'd get an exception / broken app when a component is removed (like the example in the unit test of toggling an image component).

I created a [minimal repro case on codesandbox](https://codesandbox.io/p/github/banderson/vite-remote-ui-example/draft/nifty-swirles) and this is what that looks like in action:

![Kapture 2023-02-10 at 23 57 46](https://user-images.githubusercontent.com/30241/218241043-853a3a75-2d59-427b-a1e3-9dad56d4f8ea.gif)


### Other notes

 - That function was added to `react-reconciler` in [PR #21039](https://github.com/facebook/react/pull/21039)
 - It is only intended to be called for ["Host Components"](https://github.com/facebook/react/blob/769b1f270e1251d9dbdce0fcbd9e92e502d059b8/packages/shared/ReactWorkTags.js#L36) / native DOM elements, but from tracing the behavior at runtime I noticed that all `createRemoteReactComponent`-generated components seem to e classified as Host Components by [the reconciler](https://github.com/facebook/react/blob/d9e0485c84b45055ba86629dc20870faca9b5973/packages/react-reconciler/src/ReactFiber.js#L484)
 - This behavior only occurs when removing previously-rendered components 
 - Full exception stack trace:

```js
Uncaught TypeError: detachDeletedInstance is not a function
    at detachFiberAfterEffects (react-reconciler.development.js:15352:9)
    at detachFiberAfterEffects (react-reconciler.development.js:15329:5)
    at detachFiberAfterEffects (react-reconciler.development.js:15329:5)
    at commitPassiveUnmountEffectsInsideOfDeletedTree_complete (react-reconciler.development.js:16750:7)
    at commitPassiveUnmountEffectsInsideOfDeletedTree_begin (react-reconciler.development.js:16735:7)
    at commitPassiveUnmountEffects_begin (react-reconciler.development.js:16634:11)
    at commitPassiveUnmountEffects (react-reconciler.development.js:16619:3)
    at flushPassiveEffectsImpl (react-reconciler.development.js:19181:3)
    at flushPassiveEffects (react-reconciler.development.js:19127:14)
    at react-reconciler.development.js:18912:9
```



