### PR TITLE
fix vanilla-js example by avoiding race condition

### DIFF
--- a/examples/vanilla-dom/app/host.js
+++ b/examples/vanilla-dom/app/host.js
@@ -15,13 +15,27 @@ customElements.define(UiTextField.name, UiTextField);
 
 const uiRoot = document.querySelector('#root');
 const textField = document.querySelector(UiTextField.name);
-const remoteIframe = document.querySelector('iframe');
+
+/*
+We use an iframe as the remote environment here, because it supports
+modules in most modern browsers. Aside from support for ES modules, there
+is nothing that prevents us from instead using a web worker as the remote
+environment. Note that, without using a separate domain, or manually
+hiding globals within the iframe, we are not actually creating a “safe”
+sandbox here, as the remote code can reach up into the parent.
+*/
+const remoteIframe = Object.assign(document.createElement('iframe'), {
+  src: './remote.html',
+  sandbox: 'allow-same-origin allow-scripts',
+  style: 'visibility: hidden; position: absolute',
+});
 
 // This creates an object that represents the remote context — in this case,
 // some JavaScript executing inside an `iframe`. We can use this object
 // to interact with the `iframe` code without having to worry about using
 // `postMessage()`.
 const remoteEndpoint = createEndpoint(fromIframe(remoteIframe));
+document.body.appendChild(remoteIframe);
 
 // This object will receive messages about UI updates from the remote context
 // and turn them into a matching tree of DOM nodes. We provide a mapping of

--- a/examples/vanilla-dom/app/index.html
+++ b/examples/vanilla-dom/app/index.html
@@ -33,24 +33,6 @@
       </p>
     </main>
 
-    <!--
-      We use an iframe as the remote environment here, because it supports
-      modules in most modern browsers. Aside from support for ES modules, there
-      is nothing that prevents us from instead using a web worker as the remote
-      environment. Note that, without using a separate domain, or manually
-      hiding globals within the iframe, we are not actually creating a “safe”
-      sandbox here, as the remote code can reach up into the parent.
-    -->
-    <iframe
-      src="./remote.html"
-      sandbox="allow-same-origin allow-scripts"
-      style="visibility: hidden; position: absolute;"
-    ></iframe>
-
-    <!--
-      This JavaScript will connect to the iframe, and begin propagating UI updates
-      into the UI element above.
-    -->
     <script type="module" src="./host.js" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
More often than not, the remote-ui-rendered button doesn't show up in the vanilla js example:

![image](https://user-images.githubusercontent.com/474248/218280697-7bc303b1-b7db-44e7-b3a3-8e3de1d5e826.png)

I did some digging and I think it's caused by a race condition.
The parent frame waits for the child to send a `remote-ui::ready` message before it allows communication: https://github.com/Shopify/remote-ui/blob/ffe48ac54ea55946c3b95c538fc57b57d13d7f90/packages/rpc/src/adaptors/iframe-parent.ts#L39

I believe that sometimes that message has already been sent by the child by the time the parent waits for it.

Maybe this entire process could be improved (the child could wait to send it's ready state until itself has received a message? 🤔) , but for now I fixed it by creating the iframe via JS and ensuring that the postMessage connection is established before the iframe is put into the dom.

🎩 
- checkout this branch (note: it's from a fork)
- `cd examples/vanilla-dom`
- `yarn start`
- Go to http://127.0.0.1:8080/
- The `Log message in remote environment` - button should show up constantly regardless how often you reload