### PR TITLE
Exposing types definitions in core package

### DIFF
--- a/.changeset/healthy-crews-build.md
+++ b/.changeset/healthy-crews-build.md
@@ -1,0 +1,5 @@
+---
+'@remote-ui/core': patch
+---
+
+Re-exposing types definitions in @remote-ui/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
   "main": "index.js",
   "module": "index.mjs",
   "esnext": "index.esnext",
+  "types": "./build/ts/index.d.ts",
   "exports": {
     ".": {
       "types": "./build/ts/index.d.ts",


### PR DESCRIPTION
Introduced in: https://github.com/Shopify/remote-ui/pull/226

Exposing `types` definition in `@remote-ui/core`.

Fixing an issue: 
```
Could not find a declaration file for module '@remote-ui/core'. '/app/node_modules/@remote-ui/core/index.js' implicitly has an 'any' type.
--
  | Try `npm i --save-dev @types/remote-ui__core` if it exists or add a new declaration (.d.ts) file containing `declare module '@remote-ui/core';`


```