### PR TITLE
Fix hot-swapping in remote-ui/core for arrays of primitive values

### DIFF
--- a/packages/core/src/root.ts
+++ b/packages/core/src/root.ts
@@ -611,12 +611,11 @@ function tryHotSwappingValues(
     return [IGNORE];
   }
 
-  seen.add(currentValue);
-
   if (
     typeof currentValue === 'function' &&
     FUNCTION_CURRENT_IMPLEMENTATION_KEY in currentValue
   ) {
+    seen.add(currentValue);
     const result: HotSwapResult = [
       typeof newValue === 'function' ? IGNORE : makeValueHotSwappable(newValue),
       [[currentValue as HotSwappableFunction<any>, newValue]],
@@ -626,12 +625,14 @@ function tryHotSwappingValues(
   }
 
   if (Array.isArray(currentValue)) {
+    seen.add(currentValue);
     const result = tryHotSwappingArrayValues(currentValue, newValue, seen);
 
     return result;
   }
 
   if (isBasicObject(currentValue) && !isRemoteFragment(currentValue)) {
+    seen.add(currentValue);
     const result = tryHotSwappingObjectValues(currentValue, newValue, seen);
 
     return result;
@@ -696,8 +697,6 @@ function makeValueHotSwappable(
 
     return wrappedFunction;
   }
-
-  seen.set(value, value);
 
   return value;
 }

--- a/packages/core/src/tests/root.test.ts
+++ b/packages/core/src/tests/root.test.ts
@@ -326,6 +326,62 @@ describe('root', () => {
       expect(funcOne).not.toHaveBeenCalled();
       expect(funcTwo).toHaveBeenCalled();
     });
+
+    it('hot-swaps arrays of primitive values', () => {
+      const receiver = createDelayedReceiver();
+
+      const root = createRemoteRoot(receiver.receive);
+      const component = root.createComponent('MyComponent', {
+        array1: [1, 2, 3, 4],
+        array2: [1, 2, 3, 4],
+      });
+
+      root.append(component);
+      root.mount();
+
+      component.updateProps({
+        array1: [1, 2, 3, 4],
+        array2: [1, 3, 4],
+      });
+
+      receiver.flush();
+
+      const {array2} = (receiver.children[0] as any).props;
+
+      expect(array2).toStrictEqual([1, 3, 4]);
+    });
+
+    it('hot-swaps arrays of primitive values nested in objects and arrays', () => {
+      const receiver = createDelayedReceiver();
+
+      const root = createRemoteRoot(receiver.receive);
+      const component = root.createComponent('MyComponent', {
+        arrays: [
+          {
+            array1: [1, 2, 3, 4],
+            array2: [1, 2, 3, 4],
+          },
+        ],
+      });
+
+      root.append(component);
+      root.mount();
+
+      component.updateProps({
+        arrays: [
+          {
+            array1: [1, 2, 3, 4],
+            array2: [1, 3, 4],
+          },
+        ],
+      });
+
+      receiver.flush();
+
+      const {arrays} = (receiver.children[0] as any).props;
+
+      expect(arrays[0].array2).toStrictEqual(expect.arrayContaining([1, 3, 4]));
+    });
   });
 });
 


### PR DESCRIPTION
## Description

There is currently an issue in remote-ui/core when we are attempting hot-swapping props in nested array and objects.

**Example:**

```js
const initialProps = {
  arrays: [
    {
      array1: [1, 2, 3, 4],
      array2: [1, 2, 3, 4],
    },
  ],
}

const updatedProps = {
  arrays: [
    {
      array1: [1, 2, 3, 4],
      array2: [1, 3, 4],
    },
  ],
}

// Actual props being suggested and applies post hot-swapping
const normalizedProps = {
  arrays: [
    {
      array1: [1, 2, 3, 4],
      array2: [1, 2, 3],
    },
  ],
}
```

What actually happens is the following:
* We iterate over `array1`
  * 1,2,3,4 is added to `seen` a set/map of values we have already iterated through
* We iterate over `array2`
  * 1,3,4 is present in our `seen` set/map because of `array` and the resolved array becomes [IGNORE, IGNORE, IGNORE]
  * Since we have "ignores", the resolved values become the first three items from the initial props.
  * We resolve to 1,2,3

## Solution

From my understanding, when iterating through updated props, we maintain sets and maps of "seen" values, which prevents us from being stuck when a self-referencing JS object is provided. For primitive values (string, integers, boolean, etc), it makes a lot less sense to mark those as `seen` since iterating through one integer doesn't mean we've iterated over every other instance of this integer.

Instead of marking primitive values as seen, we can only add complex structures (functions, objects, remote fragments) in those sets/maps. When a primitive value attempts hot-swapping, we can rely on the existing value comparison to infer if we need to ignore a prop.

👇🏼 

```ts
const result: HotSwapResult = [currentValue === newValue ? IGNORE : newValue];
```

## Notes
* I recommend looking at the commits separately to first see the tests I've added that are failing and then the changes to remote-ui core fixing those.
* There is other ways to fix this issue, but it seemed like a decent place to solve this. I don't think there's a use-case where we need to mark primitive values as seen where a value check wouldn't be more accurate.
* I didn't add tests to other nested complex types that might have benefited from us always marking values as seen. It might be useful to also cover remote fragments and basic objects.