### PR TITLE
Handle callId being potentially undefined

### DIFF
--- a/.changeset/giant-points-double.md
+++ b/.changeset/giant-points-double.md
@@ -1,0 +1,5 @@
+---
+'@remote-ui/rpc': patch
+---
+
+Handle cases where callId in results may be undefined

--- a/packages/rpc/src/endpoint.ts
+++ b/packages/rpc/src/endpoint.ts
@@ -201,7 +201,7 @@ export function createEndpoint<T>(
       case RESULT: {
         const [callId] = data[1] as MessageMap[typeof RESULT];
 
-        callIdsToResolver.get(callId)!(
+        callIdsToResolver.get(callId)?.(
           ...(data[1] as MessageMap[typeof RESULT]),
         );
         callIdsToResolver.delete(callId);
@@ -215,7 +215,7 @@ export function createEndpoint<T>(
       case FUNCTION_RESULT: {
         const [callId] = data[1] as MessageMap[typeof FUNCTION_RESULT];
 
-        callIdsToResolver.get(callId)!(
+        callIdsToResolver.get(callId)?.(
           ...(data[1] as MessageMap[typeof FUNCTION_RESULT]),
         );
         callIdsToResolver.delete(callId);


### PR DESCRIPTION
Hopeful fix for Shopify/checkout-web#26840.

I've not proven this fixes the issue, but it seems likely.

We were using a non-null assertion to claim that the `callId` could never be undefined, however in the real world we've been seeing lots of cases where it is undefined. So handle that at runtime using optional chaining.