### PR TITLE
Remvoe need for casting in rpc endpoint

### DIFF
--- a/packages/rpc/src/tests/endpoint.test.ts
+++ b/packages/rpc/src/tests/endpoint.test.ts
@@ -1,5 +1,5 @@
 import {MessageEndpoint} from '../types';
-import {createEndpoint, TERMINATE} from '../endpoint';
+import {createEndpoint, MESSAGE_IDS} from '../endpoint';
 import {fromMessagePort} from '../adaptors';
 import {release, retain} from '../memory';
 
@@ -164,7 +164,10 @@ describe('createEndpoint()', () => {
 
       endpoint.terminate();
 
-      expect(messageSpy).toHaveBeenCalledWith([TERMINATE], undefined);
+      expect(messageSpy).toHaveBeenCalledWith(
+        [MESSAGE_IDS.TERMINATE],
+        undefined,
+      );
     });
 
     it('does not send memory management messages to a terminated endpoint', async () => {


### PR DESCRIPTION
When digging into a some errors in this file I found there was a bunch of `as MessageMap[typeof SOMETHING]` casting happening because we structured this code in a way that typescript isn't able to infer data shapes on its own.

This PR refactors the contents of this file so that the `data` variable is typed in a way that when you use the `switch` statement to pick a shape based on the value of `data[0]`, the value of `data[1]` is correctly narrowed to the expected type without the need for casting from any


## Tophat

Inspect the the type of the `data` / `data[1]` values within the switch statement and see that they get correctly inferred.
