### PR TITLE
Fix documentation for wrong version of react-reconciler using React 17

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -20,7 +20,7 @@ npm install @remote-ui/react --save
 
 This package also has peer dependencies on a few React-related packages, but the versions you need depend on the version of React you are using:
 
-**React 17.x.x**: you will need to have React installed. Additionally, if you are in the “remote” environment, you will need a dependency on `react-reconciler` between greater than or equal to `0.26.0`, and less than `0.27.0`:
+**React 17.x.x**: you will need to have React installed. Additionally, if you are in the “remote” environment, you will need a dependency on `react-reconciler` greater than or equal to `0.26.0`, and less than `0.27.0`:
 
 ```
 yarn add react@^17.0.0 react-reconciler@~0.26.0


### PR DESCRIPTION
The current documentation for @remote-ui/react docs (https://github.com/Shopify/remote-ui/tree/main/packages/react#react-peer-dependencies) say:

> This package also has peer dependencies on a few React-related packages, but the versions you need depend on the version of React you are using:
> React 17.x.x: you will need to have React installed. Additionally, if you are in the “remote” environment, you will need a dependency on react-reconciler between greater than or equal to 0.26.0, and less than 0.28.0:
> ```
> yarn add react@^17.0.0 react-reconciler@^0.27.0
> ```

I had installed the following: React@17.0.1 and react-reconciler@0.27.0 but was getting strange exceptions with react-reconciler:

```
react-reconciler.development.js:17721 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'isBatchingLegacy')
    at ensureRootIsScheduled (react-reconciler.development.js:17721:1)
    at scheduleUpdateOnFiber (react-reconciler.development.js:17572:1)
    at Object.updateContainer (react-reconciler.development.js:20950:1)
    at render (vendor.de5598e3045c07ba7a30.8f39df85c47f6292117e.js:1416:14)
    at Object.render (vendor.de5598e3045c07ba7a30.8f39df85c47f6292117e.js:1370:7)
    at renderView (index.js:397:1)
    at listener (vendor.de5598e3045c07ba7a30.8f39df85c47f6292117e.js:484:67)
    at wrappedListener (vendor.de5598e3045c07ba7a30.8f39df85c47f6292117e.js:1297:9)
```

Looking at NPM dependency on react-reconciler@0.27.0, it only supports React@>=18 and < 19 (https://www.npmjs.com/package/react-reconciler/v/0.27.0?activeTab=code)

```
  "peerDependencies": {
    "react": "^18.0.0"
  },
```

Looking at react-reconciler 0.26.2, it only supports React@>=17 and < 18 (https://www.npmjs.com/package/react-reconciler/v/0.27.0?activeTab=code):

```
  "peerDependencies": {
    "react": "^17.0.2"
  },
```

This pull request updates the documentation to match the correct peer dependencies for React 17 using react-reconciler ~0.26.0.