### PR TITLE
Fix parameter type for Node.trigger

### DIFF
--- a/.changeset/shaggy-ladybugs-hang.md
+++ b/.changeset/shaggy-ladybugs-hang.md
@@ -1,0 +1,5 @@
+---
+'@remote-ui/testing': patch
+---
+
+Fixes parameter type for Node.trigger

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.2
+
+### Patch Changes
+
+- [#253](https://github.com/Shopify/remote-ui/pull/253) Fixes parameter type for Node.trigger.
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 1.4.2
-
-### Patch Changes
-
-- [#253](https://github.com/Shopify/remote-ui/pull/253) Fixes parameter type for Node.trigger.
-
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -72,5 +72,5 @@ type MaybeFunctionReturnType<T> = T extends (...args: any[]) => any
   : unknown;
 
 type MaybeFunctionParameters<T> = T extends (...args: any[]) => any
-  ? ReturnType<T>
+  ? Parameters<T>
   : [];


### PR DESCRIPTION
While writing tests for a Checkout UI extension, I noticed the type signature for `trigger` seemed to be incorrect as it was inferring the function's return type as the function's parameters type. This may have been a copy-paste error from https://github.com/Shopify/remote-ui/pull/223/files#diff-0eca05e10e9cb7143453a3be68ba1617a04bb006cf58988be21b759143d4c339R73-R76.

I tested this locally with `yarn link` and verified the type inference is now working correctly.