### PR TITLE
update rpc deps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "updateInternalDependents": "always"
+  }
 }

--- a/.changeset/eighty-snakes-behave.md
+++ b/.changeset/eighty-snakes-behave.md
@@ -1,0 +1,8 @@
+---
+'@remote-ui/async-subscription': patch
+'@remote-ui/core': patch
+'@remote-ui/react': patch
+'@remote-ui/vue': patch
+---
+
+bump rpc dep versions

--- a/packages/async-subscription/package.json
+++ b/packages/async-subscription/package.json
@@ -20,6 +20,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@remote-ui/rpc": "^1.4.3"
+    "@remote-ui/rpc": "^1.4.5"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@remote-ui/rpc": "^1.4.3",
+    "@remote-ui/rpc": "^1.4.5",
     "@remote-ui/types": "^1.1.3"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@remote-ui/async-subscription": "^2.1.14",
     "@remote-ui/core": "^2.2.2",
-    "@remote-ui/rpc": "^1.4.3",
+    "@remote-ui/rpc": "^1.4.5",
     "@types/react": ">=17.0.0 <19.0.0",
     "@types/react-reconciler": ">=0.26.0 <0.30.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@remote-ui/core": "^2.2.2",
-    "@remote-ui/rpc": "^1.4.3",
+    "@remote-ui/rpc": "^1.4.5",
     "@vue/runtime-core": ">=3.0.0 <4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the rpc version that other packages depend on.

Also enables the [`updateInternalDependents` setting](https://github.com/changesets/changesets/blob/main/docs/experimental-options.md#updateinternaldependents-type-out-of-range--always) which should ensure that packages get automatically updated from now on.

When this PR is merged, we'll see if this cascades through properly when the version bump PR is created or if we'll need to do multiple rounds of updating packages. 

E.g. `core` needs to get updated as a result of this, but other deps depend on `core and would need to depend on that new version. Not sure if that'll work out of the box.