### PR TITLE
Fix a few grammar errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Finally, we need to provide a “real” implementation of our `ui-button` eleme
         // but only if the element has a matching property defined. Otherwise, the remote
         // properties will be set as attributes. We’ll observe the `primary` attribute
         // in order to update our rendered content when that attribute changes. We’ll
-        // define a `onClick` method, though, which will be set to the value of the `onClick`
+        // define an `onClick` method, though, which will be set to the value of the `onClick`
         // remote property.
         static get observedAttributes() {
           return ['primary'];


### PR DESCRIPTION
## TLDR

Fix some grammar errors in the README

## Summary

- From "we’re not current rendering" to "we’re not currently rendering" in 67b7faeae9e976b071309d18e51df32803eab396. 
- From "will be update over time" to "will be updated over time" in 23202ec848f411c310a6bac9173bd11b7aad590a.
- From "a `onClick`" to "an `onClick`" in 148be5aec73ff0de3ec2bc67dbd42a7b3523435a. 