### PR TITLE
Fix missing attributes and event listeners on root receiver elements

### DIFF
--- a/.changeset/wet-mirrors-bathe.md
+++ b/.changeset/wet-mirrors-bathe.md
@@ -1,0 +1,6 @@
+---
+'@remote-dom/signals': patch
+'@remote-dom/core': patch
+---
+
+Fix missing attributes and event listeners on root receiver elements

--- a/packages/core/source/receivers/RemoteReceiver.ts
+++ b/packages/core/source/receivers/RemoteReceiver.ts
@@ -61,6 +61,10 @@ export interface RemoteReceiverRoot {
   readonly type: typeof NODE_TYPE_ROOT;
   readonly children: readonly RemoteReceiverNode[];
   readonly properties: NonNullable<RemoteElementSerialization['properties']>;
+  readonly attributes: NonNullable<RemoteElementSerialization['attributes']>;
+  readonly eventListeners: NonNullable<
+    RemoteElementSerialization['eventListeners']
+  >;
   readonly version: number;
 }
 
@@ -102,6 +106,8 @@ export class RemoteReceiver {
     children: [],
     version: 0,
     properties: {},
+    attributes: {},
+    eventListeners: {},
   };
 
   /**

--- a/packages/signals/source/SignalRemoteReceiver.ts
+++ b/packages/signals/source/SignalRemoteReceiver.ts
@@ -72,6 +72,12 @@ export interface SignalRemoteReceiverRoot {
   readonly properties: ReadonlySignal<
     NonNullable<RemoteElementSerialization['properties']>
   >;
+  readonly attributes: ReadonlySignal<
+    NonNullable<RemoteElementSerialization['attributes']>
+  >;
+  readonly eventListeners: ReadonlySignal<
+    NonNullable<RemoteElementSerialization['eventListeners']>
+  >;
   readonly children: ReadonlySignal<readonly SignalRemoteReceiverNode[]>;
 }
 
@@ -111,6 +117,8 @@ export class SignalRemoteReceiver {
     id: ROOT_ID,
     type: NODE_TYPE_ROOT,
     properties: signal({}),
+    attributes: signal({}),
+    eventListeners: signal({}),
     children: signal([]),
   };
 


### PR DESCRIPTION
You are supposed to be able to edit attributes, properties, and event listeners on all elements in the tree, including the root, but I forgot to create the necessary objects to store attributes or event listeners on the root element. This PR fixes that.