### PR TITLE
return early if falling back to `setTimeout` for MessageChannel

### DIFF
--- a/.changeset/olive-owls-search.md
+++ b/.changeset/olive-owls-search.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/core': patch
+---
+
+return early if falling back to setTimeout for MessageChannel

--- a/packages/core/source/elements/connection.ts
+++ b/packages/core/source/elements/connection.ts
@@ -58,6 +58,7 @@ function createDefaultBatchFunction() {
       setTimeout(() => {
         queue();
       }, 0);
+      return;
     }
 
     // `MessageChannel` trick that forces the code to run on the next task.


### PR DESCRIPTION
In this PR, we've corrected an issue where the fallback to `setTimeout` in the `BatchingRemoteConnection` did not properly halt further execution, attempting to use the constructor even when `MessageChannel` was not available. 

This error particularly impacted tests run in a `jsdom` environment. Now, we ensure an early return if `MessageChannel` is unavailable to prevent this issue