### PR TITLE
Make `removeChild` in receivers less strict

### DIFF
--- a/.changeset/soft-chefs-compare.md
+++ b/.changeset/soft-chefs-compare.md
@@ -1,0 +1,6 @@
+---
+'@remote-dom/signals': minor
+'@remote-dom/core': minor
+---
+
+Make `removeChild` less strict in receivers

--- a/packages/core/source/receivers/RemoteReceiver.ts
+++ b/packages/core/source/receivers/RemoteReceiver.ts
@@ -193,11 +193,16 @@ export class RemoteReceiver {
           index,
           1,
         );
+
+        if (!removed) {
+          return;
+        }
+
         parent.version += 1;
 
         runSubscribers(parent);
 
-        detach(removed!);
+        detach(removed);
       },
       updateProperty: (
         id,

--- a/packages/signals/source/SignalRemoteReceiver.ts
+++ b/packages/signals/source/SignalRemoteReceiver.ts
@@ -179,9 +179,13 @@ export class SignalRemoteReceiver {
 
         const [removed] = newChildren.splice(index, 1);
 
+        if (!removed) {
+          return;
+        }
+
         (parent.children as any).value = newChildren;
 
-        detach(removed!);
+        detach(removed);
       },
       updateProperty: (
         id,


### PR DESCRIPTION
Porting https://github.com/Shopify/remote-dom/pull/522 since through the adapter `remote-dom` receivers can be used with `remote-ui` remote which can be using old versions of `remote-ui` that don't handle `removeChild` calls well.