### PR TITLE
Use the same core dependency version for all packages

### DIFF
--- a/.changeset/lovely-turkeys-grab.md
+++ b/.changeset/lovely-turkeys-grab.md
@@ -1,0 +1,7 @@
+---
+'@remote-dom/compat': patch
+'@remote-dom/preact': patch
+'@remote-dom/react': patch
+---
+
+Use the same core dependency version for all packages

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -29,7 +29,7 @@
     "build": "rollup --config ./rollup.config.js"
   },
   "dependencies": {
-    "@remote-dom/core": "workspace:^1.6.0",
+    "@remote-dom/core": "workspace:^1.7.0",
     "@remote-ui/core": "^2.0.0"
   },
   "browserslist": [

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -55,7 +55,7 @@
     "build": "rollup --config rollup.config.js"
   },
   "dependencies": {
-    "@remote-dom/core": "workspace:^1.6.0",
+    "@remote-dom/core": "workspace:^1.7.0",
     "@remote-dom/signals": "workspace:^2.0.0",
     "htm": "^3.1.1"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,7 +68,7 @@
     "build": "rollup --config rollup.config.js"
   },
   "dependencies": {
-    "@remote-dom/core": "workspace:^1.5.0",
+    "@remote-dom/core": "workspace:^1.7.0",
     "@types/react": "^18.0.0",
     "htm": "^3.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
   packages/compat:
     dependencies:
       '@remote-dom/core':
-        specifier: workspace:^1.6.0
+        specifier: workspace:^1.7.0
         version: link:../core
       '@remote-ui/core':
         specifier: ^2.0.0
@@ -166,7 +166,7 @@ importers:
   packages/preact:
     dependencies:
       '@remote-dom/core':
-        specifier: workspace:^1.6.0
+        specifier: workspace:^1.7.0
         version: link:../core
       '@remote-dom/signals':
         specifier: workspace:^2.0.0
@@ -191,7 +191,7 @@ importers:
   packages/react:
     dependencies:
       '@remote-dom/core':
-        specifier: workspace:^1.5.0
+        specifier: workspace:^1.7.0
         version: link:../core
       '@types/react':
         specifier: ^18.0.0


### PR DESCRIPTION
`changesets` doesn't automatically bump the dependency versions in unchanged packages