### PR TITLE
Handle reordering in adapter

### DIFF
--- a/.changeset/famous-olives-sit.md
+++ b/.changeset/famous-olives-sit.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/compat': patch
+---
+
+Handle reordering in adapter

--- a/packages/compat/source/tests/adapter.test.ts
+++ b/packages/compat/source/tests/adapter.test.ts
@@ -457,6 +457,96 @@ describe('adaptToLegacyRemoteChannel()', () => {
       ]);
     });
 
+    it('inserts a child with an id that already exists', () => {
+      const receiver = new TestRemoteReceiver();
+      const channel = adaptToLegacyRemoteChannel(receiver.connection);
+
+      channel(ACTION_MOUNT, [
+        {
+          id: '1',
+          kind: KIND_COMPONENT,
+          type: 'Banner',
+          props: {title: 'Title'},
+          children: [
+            {
+              id: '2',
+              kind: KIND_COMPONENT,
+              type: 'Button',
+              props: {},
+              children: [],
+            },
+            {
+              id: '3',
+              kind: KIND_TEXT,
+              text: 'I am a text',
+            },
+          ],
+        },
+      ]);
+
+      channel(
+        ACTION_INSERT_CHILD,
+        '1',
+        1,
+        {
+          id: '2',
+          kind: KIND_COMPONENT,
+          type: 'Button',
+          props: {},
+          children: [],
+        },
+        false,
+      );
+
+      expect(receiver.connection.mutate).toHaveBeenCalledWith([
+        [MUTATION_TYPE_REMOVE_CHILD, '1', 0],
+        [
+          MUTATION_TYPE_INSERT_CHILD,
+          '1',
+          {
+            id: '2',
+            type: NODE_TYPE_ELEMENT,
+            element: 'Button',
+            properties: {},
+            children: [],
+          },
+          1,
+        ],
+      ]);
+
+      expect(receiver.root.children).toStrictEqual([
+        {
+          id: '1',
+          type: NODE_TYPE_ELEMENT,
+          element: 'Banner',
+          children: [
+            {
+              id: '3',
+              type: NODE_TYPE_TEXT,
+              data: 'I am a text',
+              version: 0,
+            },
+            {
+              id: '2',
+              type: NODE_TYPE_ELEMENT,
+              element: 'Button',
+              children: [],
+              properties: {},
+              attributes: {},
+              eventListeners: {},
+              version: 0,
+            },
+          ],
+          properties: {
+            title: 'Title',
+          },
+          attributes: {},
+          eventListeners: {},
+          version: 2,
+        },
+      ]);
+    });
+
     it('inserts child with fragment props', () => {
       const receiver = new TestRemoteReceiver();
 


### PR DESCRIPTION
The `remote-ui` to `remote-dom` adapter currently can't handle reordering which is achieved through `LEGACY_ACTION_INSERT_CHILD` instructions containing children with the same `id` that already exist in the DOM.

This PR mimics the [original logic](https://github.com/Shopify/remote-dom/blob/remote-ui/packages/core/src/receiver.ts#L169-L173), without keeping the `removed` child though as the adapter doesn't have access to the attached children.

#### Before

https://github.com/user-attachments/assets/b0ce4d5f-e93b-43cd-8e5b-a4133dfae163

#### After

https://github.com/user-attachments/assets/5b15aa9e-f8f5-4226-8d7b-ef4ff52d753d

