### PR TITLE
Adds previouslyResolved and terminated to MissingResolverError

### DIFF
--- a/.changeset/four-lemons-sleep.md
+++ b/.changeset/four-lemons-sleep.md
@@ -1,0 +1,5 @@
+---
+'@remote-ui/rpc': patch
+---
+
+Adds previouslyResolved and terminated to MissingResolverError


### PR DESCRIPTION
Adds `previouslyResolved` and `terminated` to the `MissingResolverError` to help understand the context `MissingResolverError` is occurring under.

### Note
I'm unsure if we should clear `previouslyResolvedCallIds` only on terminate or if there are other circumstances it should be cleared. It's possible the use the same `callId` for a resolver multiple times successfully since it's removed from `callIdsToResolver` after it's used. So _may_ be a chance the error throws with `previouslyResolved = true` when that wasn't the cause 🤔 