### PR TITLE
Support multiple arguments in event listeners

### DIFF
--- a/.changeset/rare-toys-develop.md
+++ b/.changeset/rare-toys-develop.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/core': minor
+---
+
+Add support for multiple arguments in event listners

--- a/packages/core/source/elements/RemoteElement.ts
+++ b/packages/core/source/elements/RemoteElement.ts
@@ -884,11 +884,11 @@ function getRemoteEventRecord(
       property,
       definition,
       listeners: new Set(),
-      dispatch: (arg: any) => {
+      dispatch: (...args: any[]) => {
         const event =
-          definition?.dispatchEvent?.call(this, arg) ??
+          definition?.dispatchEvent?.apply(this, args) ??
           new RemoteEvent(type, {
-            detail: arg,
+            detail: args[0],
             bubbles: definition?.bubbles,
           });
 

--- a/packages/core/source/elements/types.ts
+++ b/packages/core/source/elements/types.ts
@@ -9,7 +9,7 @@ export interface RemoteElementAttributeDefinition {}
 export interface RemoteElementEventListenerDefinition {
   bubbles?: boolean;
   property?: boolean | string;
-  dispatchEvent?(this: Element, arg: any): Event | undefined | void;
+  dispatchEvent?(this: Element, ...args: any[]): Event | undefined | void;
 }
 
 /**


### PR DESCRIPTION
There is no need to restrict event listeners to only accepting a single argument when custom dispatchers are used.

Besides, `dispatch` on `RemoteEventRecord` is already defined as being able to accept multiple arguments. All but the first one were thrown out though.