### PR TITLE
Fix DocumentFragment ownerDocument

### DIFF
--- a/.changeset/pretty-bags-cheer.md
+++ b/.changeset/pretty-bags-cheer.md
@@ -1,0 +1,6 @@
+---
+'@remote-dom/polyfill': patch
+'@remote-dom/core': patch
+---
+
+Fix document fragment owner document

--- a/packages/polyfill/source/DocumentFragment.ts
+++ b/packages/polyfill/source/DocumentFragment.ts
@@ -4,5 +4,7 @@ import {ParentNode} from './ParentNode.ts';
 export class DocumentFragment extends ParentNode {
   nodeType = NodeType.DOCUMENT_FRAGMENT_NODE;
   [NAME] = '#document-fragment';
-  [OWNER_DOCUMENT] = window.document as any;
+  [OWNER_DOCUMENT] = (typeof window !== 'undefined'
+    ? window.document
+    : null) as any;
 }


### PR DESCRIPTION
In some cases, `window` is not available globally. This adds a safeguard for accessing `window.document`