### PR TITLE
prep snapit for OIDC

### DIFF
--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -9,6 +9,10 @@ jobs:
   snapit:
     name: Snapit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write # Required for OIDC authentication
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -16,12 +20,15 @@ jobs:
 
       - uses: ./.github/workflows/actions/prepare
 
+      - name: Update npm to 11.7
+        run: npm install -g npm@11.7
+
       - name: Create snapshot
-        uses: Shopify/snapit@v0.0.14
+        uses: Shopify/snapit@v0.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: '' # Empty string forces OIDC
+          NPM_CONFIG_PROVENANCE: true
         with:
           build_script: pnpm build:snapit
           comment_command: /snapit


### PR DESCRIPTION
see https://github.com/Shopify/ui-extensions/blob/2026-07-rc/.github/workflows/deploy.yml#L26 as an example for a config that has been updated alredy

We're bumping snapit so it works with OIDC and we're adding the necessary permissions. 

We can't test this yet unfortunately. So we might have to make some adjustments soon.