### PR TITLE
Fix ParentNode insertBefore linked-list corruption

### DIFF
--- a/.changeset/young-owls-kick.md
+++ b/.changeset/young-owls-kick.md
@@ -1,0 +1,5 @@
+---
+'@remote-dom/polyfill': patch
+---
+
+Fix linked-list corruption when inserting a child before a non-head sibling.

--- a/packages/polyfill/source/ParentNode.ts
+++ b/packages/polyfill/source/ParentNode.ts
@@ -124,6 +124,7 @@ export class ParentNode extends ChildNode {
       child[NEXT] = before;
       child[PREV] = before[PREV];
       if (before[PREV] === null) this[CHILD] = child;
+      else before[PREV][NEXT] = child;
       before[PREV] = child;
     } else {
       child[NEXT] = null;

--- a/packages/polyfill/source/tests/parent-node.test.ts
+++ b/packages/polyfill/source/tests/parent-node.test.ts
@@ -1,0 +1,63 @@
+import {Window} from '../index.ts';
+
+import {describe, it, expect, beforeEach} from 'vitest';
+
+describe('ParentNode', () => {
+  beforeEach(() => {
+    const window = new Window();
+    Window.setGlobalThis(window);
+  });
+
+  it('updates sibling links when inserting before a non-head child', () => {
+    const parent = document.createElement('div');
+    const first = document.createElement('first');
+    const second = document.createElement('second');
+    const third = document.createElement('third');
+    const inserted = document.createElement('inserted');
+
+    parent.append(first, second, third);
+    parent.insertBefore(inserted, second);
+
+    expect([...parent.childNodes]).toStrictEqual([
+      first,
+      inserted,
+      second,
+      third,
+    ]);
+    expect(nodesFromSiblingLinks(parent)).toStrictEqual([...parent.childNodes]);
+    expect(first.nextSibling).toBe(inserted);
+    expect(inserted.previousSibling).toBe(first);
+    expect(inserted.nextSibling).toBe(second);
+    expect(second.previousSibling).toBe(inserted);
+  });
+
+  it('updates sibling links when moving a child before a non-head child', () => {
+    const parent = document.createElement('div');
+    const first = document.createElement('first');
+    const second = document.createElement('second');
+    const third = document.createElement('third');
+    const moved = document.createElement('moved');
+
+    parent.append(first, second, third, moved);
+    parent.insertBefore(moved, second);
+
+    expect([...parent.childNodes]).toStrictEqual([first, moved, second, third]);
+    expect(nodesFromSiblingLinks(parent)).toStrictEqual([...parent.childNodes]);
+    expect(first.nextSibling).toBe(moved);
+    expect(moved.previousSibling).toBe(first);
+    expect(moved.nextSibling).toBe(second);
+    expect(second.previousSibling).toBe(moved);
+  });
+});
+
+function nodesFromSiblingLinks(parent: Node) {
+  const nodes: Node[] = [];
+  let node = parent.firstChild;
+
+  while (node) {
+    nodes.push(node);
+    node = node.nextSibling;
+  }
+
+  return nodes;
+}


### PR DESCRIPTION
## Summary

This fixes `ParentNode.insertInto()` in `@remote-dom/polyfill` so inserting a child before a non-head reference node correctly links the previous sibling to the inserted child.

The current implementation updates the inserted child and the reference node, but it does not update the previous sibling's `NEXT` pointer when `before[PREV]` is not `null`. That leaves the sibling list internally inconsistent: the inserted node has `PREV`/`NEXT` links, and the reference node points back to it, but traversal from the parent's first child skips the inserted node.

Affected source:
https://github.com/Shopify/remote-dom/blob/main/packages/polyfill/source/ParentNode.ts#L120-L127

Before:

```ts
child[NEXT] = before;
child[PREV] = before[PREV];
if (before[PREV] === null) this[CHILD] = child;
before[PREV] = child;
```

After:

```ts
child[NEXT] = before;
child[PREV] = before[PREV];
if (before[PREV] === null) this[CHILD] = child;
else before[PREV][NEXT] = child; // Link the previous sibling to the inserted child.
before[PREV] = child;
```

Tests passed: `corepack pnpm exec vitest run packages/polyfill/source/tests/parent-node.test.ts`, `corepack pnpm type-check`, `corepack pnpm lint`, and `corepack pnpm exec vitest run`.

## Root Cause

For non-head insertions, `before[PREV]` is the previous sibling. That sibling must have its `NEXT` pointer changed to the inserted child. Without that update, the list can become inconsistent after DOM moves such as keyed reorders.

This diverges from the normal DOM insertion invariant:

```text
previousSibling -> insertedChild -> before
```

Instead, the current state can become:

```text
previousSibling -> before
insertedChild -> before
before.prev -> insertedChild
```