### PR TITLE
Fix ParentNode insertBefore linked-list corruption

### DIFF
--- a/packages/polyfill/source/ParentNode.ts
+++ b/packages/polyfill/source/ParentNode.ts
@@ -124,6 +124,7 @@ export class ParentNode extends ChildNode {
       child[NEXT] = before;
       child[PREV] = before[PREV];
       if (before[PREV] === null) this[CHILD] = child;
+      else before[PREV][NEXT] = child;
       before[PREV] = child;
     } else {
       child[NEXT] = null;


### PR DESCRIPTION
## Summary

This fixes `ParentNode.insertInto()` in `@remote-dom/polyfill` so inserting a child before a non-head reference node correctly links the previous sibling to the inserted child.

The current implementation updates the inserted child and the reference node, but it does not update the previous sibling's `NEXT` pointer when `before[PREV]` is not `null`. That leaves the sibling list internally inconsistent: the inserted node has `PREV`/`NEXT` links, and the reference node points back to it, but traversal from the parent's first child skips the inserted node.

Affected source:
https://github.com/Shopify/remote-dom/blob/main/packages/polyfill/source/ParentNode.ts#L120-L127

Before:

```ts
child[NEXT] = before;
child[PREV] = before[PREV];
if (before[PREV] === null) this[CHILD] = child;
before[PREV] = child;
```

After:

```ts
child[NEXT] = before;
child[PREV] = before[PREV];
if (before[PREV] === null) this[CHILD] = child;
else before[PREV][NEXT] = child; // Link the previous sibling to the inserted child.
before[PREV] = child;
```

Tests passed: `corepack pnpm type-check`, `corepack pnpm lint`, and `corepack pnpm exec vitest run`.

## Root Cause

For non-head insertions, `before[PREV]` is the previous sibling. That sibling must have its `NEXT` pointer changed to the inserted child. Without that update, the list can become inconsistent after DOM moves such as keyed reorders.

This diverges from the normal DOM insertion invariant:

```text
previousSibling -> insertedChild -> before
```

Instead, the current state can become:

```text
previousSibling -> before
insertedChild -> before
before.prev -> insertedChild
```