### PR TITLE
Implement getElementById on Document and DocumentFragment

### DIFF
--- a/.changeset/polyfill-get-element-by-id.md
+++ b/.changeset/polyfill-get-element-by-id.md
@@ -1,0 +1,9 @@
+---
+'@remote-dom/polyfill': minor
+---
+
+Implement `getElementById()` on `Document` and `DocumentFragment`
+
+The polyfill gave `ParentNode` `querySelector()` and `querySelectorAll()`, but the `NonElementParentNode.getElementById()` lookup was missing, so `document.getElementById(id)` threw `document.getElementById is not a function` inside a remote environment. Because host code is typically type-checked against `lib.dom`, which does declare the method, this failure was invisible to static checks and only surfaced at runtime.
+
+The lookup returns the first element in tree order whose `id` attribute matches, and matches that attribute literally rather than delegating to `querySelector('#' + id)` — an id is a string, not a selector, and the selector tokenizer has no escape handling, so an id containing `.`, `:`, `[`, or whitespace would otherwise parse as a different selector.

--- a/packages/polyfill/source/Document.ts
+++ b/packages/polyfill/source/Document.ts
@@ -17,7 +17,7 @@ import {Text} from './Text.ts';
 import {Comment} from './Comment.ts';
 import {DocumentFragment} from './DocumentFragment.ts';
 import {HTMLTemplateElement} from './HTMLTemplateElement.ts';
-import {isParentNode, cloneNode} from './shared.ts';
+import {isParentNode, cloneNode, getElementById} from './shared.ts';
 import {HTMLBodyElement} from './HTMLBodyElement.ts';
 import {HTMLHeadElement} from './HTMLHeadElement.ts';
 import {HTMLHtmlElement} from './HTMLHtmlElement.ts';
@@ -42,6 +42,10 @@ export class Document extends ParentNode {
     this.appendChild(this.documentElement);
     this.documentElement.appendChild(this.head);
     this.documentElement.appendChild(this.body);
+  }
+
+  getElementById(elementId: string) {
+    return getElementById(this, elementId);
   }
 
   createElement(localName: string) {

--- a/packages/polyfill/source/DocumentFragment.ts
+++ b/packages/polyfill/source/DocumentFragment.ts
@@ -1,5 +1,6 @@
 import {NAME, OWNER_DOCUMENT, NodeType} from './constants.ts';
 import {ParentNode} from './ParentNode.ts';
+import {getElementById} from './shared.ts';
 
 export class DocumentFragment extends ParentNode {
   nodeType = NodeType.DOCUMENT_FRAGMENT_NODE;
@@ -7,4 +8,8 @@ export class DocumentFragment extends ParentNode {
   [OWNER_DOCUMENT] = (typeof window !== 'undefined'
     ? window.document
     : null) as any;
+
+  getElementById(elementId: string) {
+    return getElementById(this, elementId);
+  }
 }

--- a/packages/polyfill/source/shared.ts
+++ b/packages/polyfill/source/shared.ts
@@ -86,6 +86,33 @@ export function cloneNode(
   }
 }
 
+/**
+ * The `NonElementParentNode.getElementById()` lookup, shared by `Document` and
+ * `DocumentFragment`.
+ *
+ * Matches the `id` attribute literally instead of delegating to
+ * `querySelector('#' + id)`: an id is a string, not a selector, and the selector
+ * tokenizer has no escape handling, so an id containing `.`, `:`, `[`, or
+ * whitespace would parse as a different selector.
+ */
+export function getElementById(within: ParentNode, id: string): Element | null {
+  const child = within[CHILD];
+  return child ? findElementById(child, String(id)) : null;
+}
+
+function findElementById(node: Node, id: string): Element | null {
+  if (isElementNode(node)) {
+    if (node.getAttribute('id') === id) return node;
+    const child = node[CHILD];
+    if (child) {
+      const found = findElementById(child, id);
+      if (found) return found;
+    }
+  }
+  const next = node[NEXT];
+  return next ? findElementById(next, id) : null;
+}
+
 export function descendants(node: Node) {
   const nodes: Node[] = [];
   const walk = (node: Node) => {

--- a/packages/polyfill/source/tests/getElementById.test.ts
+++ b/packages/polyfill/source/tests/getElementById.test.ts
@@ -1,0 +1,94 @@
+import {Window} from '../index.ts';
+
+import {describe, it, expect, beforeEach} from 'vitest';
+
+describe('NonElementParentNode.getElementById', () => {
+  beforeEach(() => {
+    const window = new Window();
+    Window.setGlobalThis(window);
+  });
+
+  describe('Document', () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <article id="main-post">
+          <h1 id="title">Main Title</h1>
+          <div class="content">
+            <p id="body">First paragraph</p>
+          </div>
+        </article>
+      `;
+    });
+
+    it('finds an element anywhere in the document', () => {
+      expect(document.getElementById('main-post')?.localName).toBe('article');
+      expect(document.getElementById('title')?.textContent).toBe('Main Title');
+      expect(document.getElementById('body')?.textContent).toBe(
+        'First paragraph',
+      );
+    });
+
+    it('returns null when no element has the id', () => {
+      expect(document.getElementById('nonexistent')).toBeNull();
+    });
+
+    it('returns the first match in tree order when ids are duplicated', () => {
+      document.body.innerHTML = `
+        <div id="dupe"><span id="inner">first</span></div>
+        <div id="dupe"><span>second</span></div>
+      `;
+
+      expect(document.getElementById('dupe')?.textContent).toBe('first');
+    });
+
+    it('matches the id literally rather than as a selector', () => {
+      // The selector tokenizer has no escape handling, so an id that looks like
+      // a compound selector must not be parsed as one.
+      const ids = ['a.b', 'a b', 'a[b]', 'a:b', 'a#b'];
+
+      for (const id of ids) {
+        const element = document.createElement('div');
+        element.setAttribute('id', id);
+        document.body.appendChild(element);
+      }
+
+      for (const id of ids) {
+        expect(document.getElementById(id)?.getAttribute('id')).toBe(id);
+      }
+    });
+
+    it('finds elements added after the document was built', () => {
+      const added = document.createElement('section');
+      added.setAttribute('id', 'added');
+      document.body.appendChild(added);
+
+      expect(document.getElementById('added')).toBe(added);
+
+      document.body.removeChild(added);
+
+      expect(document.getElementById('added')).toBeNull();
+    });
+  });
+
+  describe('DocumentFragment', () => {
+    it('finds an element within the fragment', () => {
+      const fragment = document.createDocumentFragment();
+      const child = document.createElement('div');
+      child.setAttribute('id', 'in-fragment');
+      fragment.appendChild(child);
+
+      expect(fragment.getElementById('in-fragment')).toBe(child);
+      expect(fragment.getElementById('nonexistent')).toBeNull();
+    });
+
+    it('does not find elements that are only in the document', () => {
+      const inDocument = document.createElement('div');
+      inDocument.setAttribute('id', 'in-document');
+      document.body.appendChild(inDocument);
+
+      const fragment = document.createDocumentFragment();
+
+      expect(fragment.getElementById('in-document')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
### Problem

`@remote-dom/polyfill` gives `ParentNode` both `querySelector()` and `querySelectorAll()`, but the `NonElementParentNode.getElementById()` lookup is missing. Inside a remote environment, `document.getElementById(id)` throws:

```
TypeError: document.getElementById is not a function
```

This is a nasty failure mode for host code, because remote code is normally type-checked against `lib.dom`, which *does* declare `getElementById`. So the call is type-clean, passes every static check, and only blows up at runtime in the sandbox. We hit exactly this in Shopify's admin: a script handler in a remote view looked up an element by id to call an imperative method on it, typechecked green, and threw as soon as the handler ran.

### Fix

Implement `getElementById()` on `Document` and `DocumentFragment` (the two `NonElementParentNode` hosts per the DOM spec — deliberately *not* on `Element`), delegating to a shared helper in `shared.ts`. This mirrors how the existing `querySelector`/`querySelectorAll` delegate to `selectors.ts`.

The helper returns the first element in tree order whose `id` attribute matches, walking the existing `CHILD`/`NEXT` links.

**It matches the `id` attribute literally rather than delegating to `querySelector('#' + id)`.** An id is a string, not a selector, and the selector tokenizer in `selectors.ts` has no escape handling — so an id containing `.`, `:`, `[`, or whitespace would parse as a different selector entirely and silently return the wrong element (or nothing). `getElementById('a.b')` must find `<div id="a.b">`, not an `<a>` with class `b`.

